### PR TITLE
Updates for Undo Output Control

### DIFF
--- a/Erik Temple/Undo Output Control.i7x
+++ b/Erik Temple/Undo Output Control.i7x
@@ -24,16 +24,24 @@ The before nothing to be undone failure rules are a rulebook.
 The report nothing to be undone failure rules are a rulebook.
 The after nothing to be undone failure rules are a rulebook.
 
-The last report undoing an action rule:
+The default report undoing an action rule is listed last in the report undoing an action rules.
+This is the default report undoing an action rule:
 	rule fails.
 
-The last report prevented undo rule:
+The default report prevented undo rule is listed last in the report prevented undo rules.
+This is the default report prevented undo rule:
 	rule fails.
 
-The last report interpreter undo failure rule:
+The default report interpreter-undo-incapacity rule is listed last in the report interpreter-undo-incapacity rules.
+This is the default report interpreter-undo-incapacity rule:
 	rule fails.
 
-The last report nothing to be undone failure rule:
+The default report interpreter undo failure rule is listed last in the report interpreter undo failure rules.
+This is the default report interpreter undo failure rule:
+	rule fails.
+
+The default report nothing to be undone failure rule is listed last in the report nothing to be undone failure rules.
+This is the default report nothing to be undone failure rule:
 	rule fails.
 
 

--- a/Erik Temple/Undo Output Control.i7x
+++ b/Erik Temple/Undo Output Control.i7x
@@ -89,6 +89,11 @@ The last report attempt to undo-while-disabled rule:
 	rule succeeds;
 
 Include (-
+
+! ==== ==== ==== ==== ==== ==== ==== ==== ==== ====
+! Undo Output Control replacement for Parser.i6t: Reading the Command
+! ==== ==== ==== ==== ==== ==== ==== ==== ==== ====
+
 [ Keyboard  a_buffer a_table  nw i w w2 x1 x2;
 	sline1 = score; sline2 = turns;
 
@@ -217,6 +222,11 @@ Include (-
 
 
 Include (-
+
+! ==== ==== ==== ==== ==== ==== ==== ==== ==== ====
+! Undo Output Control replacement for OutOfWorld.i6t: Perform Undo
+! ==== ==== ==== ==== ==== ==== ==== ==== ==== ====
+
 [ Perform_Undo;
 	#ifdef PREVENT_UNDO; 
 	if ( FollowRulebook( (+ report prevented undo rules +) ) && RulebookFailed()) { 
@@ -267,6 +277,11 @@ Include (-
 Section - Patches (for use with Conditional Undo by Jesse McGrew)
 
 Include (-
+
+! ==== ==== ==== ==== ==== ==== ==== ==== ==== ====
+! Undo Output Control replacement for Parser.i6t: Reading the Command
+! ==== ==== ==== ==== ==== ==== ==== ==== ==== ====
+
 [ Keyboard  a_buffer a_table  nw i w w2 x1 x2;
 	sline1 = score; sline2 = turns;
 
@@ -396,6 +411,11 @@ Include (-
 -) instead of "Reading the Command" in "Parser.i6t".
 
 Include (-
+
+! ==== ==== ==== ==== ==== ==== ==== ==== ==== ====
+! Undo Output Control replacement for OutOfWorld.i6t: Perform Undo
+! ==== ==== ==== ==== ==== ==== ==== ==== ==== ====
+
 [ Perform_Undo;
 	#ifdef PREVENT_UNDO; 
 	if ( FollowRulebook( (+ report prevented undo rules +) ) && RulebookFailed()) { 

--- a/Erik Temple/Undo Output Control.i7x
+++ b/Erik Temple/Undo Output Control.i7x
@@ -245,18 +245,22 @@ Include (-
 		return; 
 	}
 	if (undo_flag == 1) { 
-		FollowRulebook ( (+ before interpreter undo failure rules +) );
-		if ( FollowRulebook( (+ report interpreter undo failure rules +) ) && RulebookFailed()) {
+		! Undo failed because the interpreter did not save a game when it was supposed to.
+		! This happens rarely under Z-Machine but may be thrown by a Glulx interpreter which can't save.
+		! For clarity of error message, this should be treated as an interpreter incapacity, not interpreter failure.
+		FollowRulebook ( (+ before interpreter-undo-incapacity rules +) );
+		if ( FollowRulebook( (+ report interpreter-undo-incapacity rules +) ) && RulebookFailed()) {
 			IMMEDIATELY_UNDO_RM('D'); new_line; return; 
 		}
-		FollowRulebook ( (+ after interpreter undo failure rules +) );
+		FollowRulebook ( (+ after interpreter-undo-incapacity rules +) );
 		return; 
 	}
 	if ( (+ temporary undo suspension +) ) {FollowRulebook ( (+ report attempt to undo-while-disabled rules +) ); return;}
 	if (VM_Undo() == 0) {
+		! Undo failed because the interpreter failed to restore, probably because the undo limit was exceeded.
 		FollowRulebook ( (+ before interpreter undo failure rules +) );
 		if ( FollowRulebook( (+ report interpreter undo failure rules +) ) && RulebookFailed()) {
-		IMMEDIATELY_UNDO_RM('F'); new_line;
+			IMMEDIATELY_UNDO_RM('F'); new_line;
 		}
 		FollowRulebook ( (+ after interpreter undo failure rules +) );
 	}
@@ -421,18 +425,22 @@ Include (-
 		return; 
 	}
 	if (undo_flag == 1) { 
-		FollowRulebook ( (+ before interpreter undo failure rules +) );
-		if ( FollowRulebook( (+ report interpreter undo failure rules +) ) && RulebookFailed()) {
+		! Undo failed because the interpreter did not save a game when it was supposed to.
+		! This happens rarely under Z-Machine but may be thrown by a Glulx interpreter which can't save.
+		! For clarity of error message, this should be treated as an interpreter incapacity, not interpreter failure.
+		FollowRulebook ( (+ before interpreter-undo-incapacity rules +) );
+		if ( FollowRulebook( (+ report interpreter-undo-incapacity rules +) ) && RulebookFailed()) {
 			IMMEDIATELY_UNDO_RM('D'); new_line; return; 
 		}
-		FollowRulebook ( (+ after interpreter undo failure rules +) );
+		FollowRulebook ( (+ after interpreter-undo-incapacity rules +) );
 		return; 
 	}
 	if (~~AllowUndo()) return;
 	if (VM_Undo() == 0) {
+		! Undo failed because the interpreter failed to restore, probably because the undo limit was exceeded.
 		FollowRulebook ( (+ before interpreter undo failure rules +) );
 		if ( FollowRulebook( (+ report interpreter undo failure rules +) ) && RulebookFailed()) {
-		IMMEDIATELY_UNDO_RM('F'); new_line;
+			IMMEDIATELY_UNDO_RM('F'); new_line;
 		}
 		FollowRulebook ( (+ after interpreter undo failure rules +) );
 	}

--- a/Erik Temple/Undo Output Control.i7x
+++ b/Erik Temple/Undo Output Control.i7x
@@ -1,6 +1,6 @@
 Version 4/161016 of Undo Output Control by Erik Temple begins here.
 
-"In addition to allowing control over UNDO default messages, provides hooks into UNDO processing, including multiple ways to suspend UNDO temporarily, to place limitations on UNDO (such as allowing only one UNDO in a row), and to control when the game state is saved. Using the latter, we can effectively control which turn UNDO returns us to."
+"In addition to allowing control over UNDO default messages, provides hooks into UNDO processing, including multiple ways to suspend UNDO temporarily, to place limitations on UNDO (such as allowing only one UNDO in a row), and to control when the game state is saved. Using the latter, we can effectively control which turn UNDO returns us to.  Also allows changing the words which invoke UNDO and OOPS.  Updated to Inform 6M62."
 
 Section - Rulebooks
 
@@ -581,10 +581,15 @@ As was mentioned above, UNDO is not an action. Along with OOPS, it is handled be
 
 Undo Output Control makes providing new vocabulary for UNDO and OOPS a bit easier. Each command has three "words" associated with it. These are, with their initial values:
 
-	UNDO					OOPS
-	undo word #1 "undo"		oops word #1 "oops"
-	undo word #2	"undo"		oops word #2 "o//"
-	undo word #3	"undo"		oops word #3 "oops"
+	UNDO
+	undo word #1	"undo"
+	undo word #2	"undo"
+	undo word #3	"undo"
+	
+	OOPS
+	oops word #1 "oops"
+	oops word #2 "o//"
+	oops word #3 "oops"
 
 We can thus add up to two vocabulary words for each command, in addition to the standard "oops" and "undo", or we can replace all three slots for each word if we like. Note that oops word #2 is a single-letter abbreviation; two forward slashes are required after single-letter words for Inform to understand them.
 
@@ -595,8 +600,13 @@ To change one of these vocabulary words, we need to define a phrase. For example
 
 The word must be placed within single quotes, and only a single word can be matched. If your text contains a space, it will never be matched.
 
+To eliminate the "o" synonym for oops:
+	To decide which value is oops word #2:
+		(- 'oops' -)
 
 Section - Change log
+
+	v4 - Substantial updates by Nathanael Nerode.  Update to 6M62.  Fix bugs. Improve documentation.
 
 	v3 - Removed unnecessary check of the "before undoing an action" rulebook at the end of the game. This caused an UNDO typed at the end of the game to fail silently.
 

--- a/Erik Temple/Undo Output Control.i7x
+++ b/Erik Temple/Undo Output Control.i7x
@@ -196,7 +196,12 @@ Include (-
 			continue;
 		}
 		if ( (+ temporary undo suspension +) ) { return; }
-		i = VM_Save_Undo();
+
+		if (+ save undo state +) {
+			i = VM_Save_Undo();
+		}
+		else { i = -2; }
+
 		#ifdef PREVENT_UNDO; undo_flag = 0; #endif;
 		#ifndef PREVENT_UNDO; undo_flag = 2; #endif;
 		
@@ -385,7 +390,12 @@ Include (-
 			continue;
 		}
 		if ( (+ prevent undo flag +) ) {return;}
-		i = VM_Save_Undo();
+
+		if (+ save undo state +) {
+			i = VM_Save_Undo();
+		}
+		else { i = -2; }
+
 		#ifdef PREVENT_UNDO; undo_flag = 0; #endif;
 		#ifndef PREVENT_UNDO; undo_flag = 2; #endif;
 
@@ -461,44 +471,6 @@ Include (-
 	}
 ];
 -) instead of "Perform Undo" in "OutOfWorld.i6t".
-
-
-Section - Undo save control
-
-Include (-
-[ VM_Undo result_code;
-	@restoreundo result_code;
-	return (~~result_code);
-];
-
-[ VM_Save_Undo result_code;
-    if (+ save undo state +) {
-       @saveundo result_code;
-       if (result_code == -1) { GGRecoverObjects(); return 2; }
-       return (~~result_code);
-   }
-   else { return -2 ; }
-];
--) instead of "Undo" in "Glulx.i6t".
-
-
-Include (-
-
-[ VM_Undo result_code;
-	@restore_undo result_code;
-	  return result_code;
-];
-
-[ VM_Save_Undo result_code;
-    if (+ save undo state +) {
-       @save_undo result_code;
-	return result_code;
-    }
-    else { return -2; }
-];
-
--) instead of "Undo" in "ZMachine.i6t".
-
 
 Undo Output Control ends here.
 

--- a/Erik Temple/Undo Output Control.i7x
+++ b/Erik Temple/Undo Output Control.i7x
@@ -84,8 +84,8 @@ To decide whether undo is suspended: decide on temporary undo suspension.
 
 The report attempt to undo-while-disabled rules are a rulebook.
 
-The last report attempt to undo-while-disabled rule:
-	say "That action cannot be undone.";
+The last report attempt to undo-while-disabled rule (this is the undoing is disabled rule):
+	say "That action cannot be undone." (A);
 	rule succeeds;
 
 Include (-

--- a/Erik Temple/Undo Output Control.i7x
+++ b/Erik Temple/Undo Output Control.i7x
@@ -242,7 +242,7 @@ Include (-
 	if (IterationsOfTurnSequence == 0) {
 		FollowRulebook ( (+ before nothing to be undone failure rules +) );
 		if ( FollowRulebook( (+ report nothing to be undone failure rules +) ) && RulebookFailed()) {
-			IMMEDIATELY_UNDO_RM('B'); new_line; return;
+			IMMEDIATELY_UNDO_RM('B'); new_line;
 		}
 		FollowRulebook ( (+ after nothing to be undone failure rules +) );
 		return; 
@@ -250,7 +250,7 @@ Include (-
 	if (undo_flag == 0) { 
 		FollowRulebook ( (+ before interpreter-undo-incapacity rules +) );
 		if ( FollowRulebook( (+ report interpreter-undo-incapacity rules +) ) && RulebookFailed()) {
-			IMMEDIATELY_UNDO_RM('C'); new_line; return;
+			IMMEDIATELY_UNDO_RM('C'); new_line;
 		}
 		FollowRulebook ( (+ after interpreter-undo-incapacity rules +) );
 		return; 
@@ -261,7 +261,7 @@ Include (-
 		! For clarity of error message, this should be treated as an interpreter incapacity, not interpreter failure.
 		FollowRulebook ( (+ before interpreter-undo-incapacity rules +) );
 		if ( FollowRulebook( (+ report interpreter-undo-incapacity rules +) ) && RulebookFailed()) {
-			IMMEDIATELY_UNDO_RM('D'); new_line; return; 
+			IMMEDIATELY_UNDO_RM('D'); new_line;
 		}
 		FollowRulebook ( (+ after interpreter-undo-incapacity rules +) );
 		return; 
@@ -436,7 +436,7 @@ Include (-
 	if (IterationsOfTurnSequence == 0) {
 		FollowRulebook ( (+ before nothing to be undone failure rules +) );
 		if ( FollowRulebook( (+ report nothing to be undone failure rules +) ) && RulebookFailed()) {
-			IMMEDIATELY_UNDO_RM('B'); new_line; return;
+			IMMEDIATELY_UNDO_RM('B'); new_line;
 		}
 		FollowRulebook ( (+ after nothing to be undone failure rules +) );
 		return; 
@@ -444,7 +444,7 @@ Include (-
 	if (undo_flag == 0) { 
 		FollowRulebook ( (+ before interpreter-undo-incapacity rules +) );
 		if ( FollowRulebook( (+ report interpreter-undo-incapacity rules +) ) && RulebookFailed()) {
-			IMMEDIATELY_UNDO_RM('C'); new_line; return;
+			IMMEDIATELY_UNDO_RM('C'); new_line;
 		}
 		FollowRulebook ( (+ after interpreter-undo-incapacity rules +) );
 		return; 
@@ -455,7 +455,7 @@ Include (-
 		! For clarity of error message, this should be treated as an interpreter incapacity, not interpreter failure.
 		FollowRulebook ( (+ before interpreter-undo-incapacity rules +) );
 		if ( FollowRulebook( (+ report interpreter-undo-incapacity rules +) ) && RulebookFailed()) {
-			IMMEDIATELY_UNDO_RM('D'); new_line; return; 
+			IMMEDIATELY_UNDO_RM('D'); new_line;
 		}
 		FollowRulebook ( (+ after interpreter-undo-incapacity rules +) );
 		return; 

--- a/Erik Temple/Undo Output Control.i7x
+++ b/Erik Temple/Undo Output Control.i7x
@@ -234,7 +234,7 @@ Include (-
 		}
 	return; 
 	#endif;
-	if (turns == 1) { 
+	if (IterationsOfTurnSequence == 0) {
 		FollowRulebook ( (+ before nothing to be undone failure rules +) );
 		if ( FollowRulebook( (+ report nothing to be undone failure rules +) ) && RulebookFailed()) {
 			IMMEDIATELY_UNDO_RM('B'); new_line; return;
@@ -423,7 +423,7 @@ Include (-
 		}
 	return; 
 	#endif;
-	if (turns == 1) { 
+	if (IterationsOfTurnSequence == 0) {
 		FollowRulebook ( (+ before nothing to be undone failure rules +) );
 		if ( FollowRulebook( (+ report nothing to be undone failure rules +) ) && RulebookFailed()) {
 			IMMEDIATELY_UNDO_RM('B'); new_line; return;

--- a/Erik Temple/Undo Output Control.i7x
+++ b/Erik Temple/Undo Output Control.i7x
@@ -618,6 +618,8 @@ However, you can use this to your advantage.  If at the end of a very long and c
 
 This can be combined with "disable saving of undo state", as demonstrated in "Purgatory II".
 
+You can also prevent the player from undoing and still use this in your code.
+
 Section - Change log
 
 	v5 - Add "undo the current turn", documentation, and example.  (Nathanael Nerode)

--- a/Erik Temple/Undo Output Control.i7x
+++ b/Erik Temple/Undo Output Control.i7x
@@ -52,9 +52,6 @@ Save undo state is a truth state that varies. Save undo state is usually true.
 To disable saving of/-- undo state: now save undo state is false.
 To enable saving of/-- undo state: now save undo state is true.
 
-The report undo saving suspended rules are a rulebook.
-
-
 Section - Word constants
 
 To decide which text is undo word #1:
@@ -198,7 +195,6 @@ Include (-
 		#ifdef PREVENT_UNDO; undo_flag = 0; #endif;
 		#ifndef PREVENT_UNDO; undo_flag = 2; #endif;
 		
-		if ((+ save undo state +)) FollowRulebook( (+ report undo saving suspended rules +) );
 		if (i == -1) undo_flag = 0;
 		if (i == 0) undo_flag = 1;
 		if (i == 2) {
@@ -378,7 +374,6 @@ Include (-
 		#ifdef PREVENT_UNDO; undo_flag = 0; #endif;
 		#ifndef PREVENT_UNDO; undo_flag = 2; #endif;
 
-		if ((+ save undo state +)) FollowRulebook( (+ report undo saving suspended rules +) );
 		if (i == -1) undo_flag = 0;
 		if (i == 0) undo_flag = 1;
 		if (i == 2) {


### PR DESCRIPTION
This fixes a number of minor bugs and infelicities in Undo Output Control, improves the rubric and documentation, and adds one feature (the ability to "undo the current turn" from code) with an example.  It also simplifies the internals to replace less I6 code, making for less interference with extensions like Ultra Undo.  Version is updated to 5.

(If you don't like one of the pieces, it's all in individual patches so you can leave that piece out.)