### PR TITLE
Updated Postures  by Emily Short

### DIFF
--- a/Emily Short/Postures.i7x
+++ b/Emily Short/Postures.i7x
@@ -315,7 +315,9 @@ Before printing an error message for an NPC, such as "Clark is already sitting" 
 
 	Use posture visibility checks.
 
-Note that this only applies to the new messages introduced by this extension. Many error messages in the Inform Standard Rules will print even if the NPC they mention is not visibile to the player.
+Note that this only applies to the new messages introduced by this extension. Some error messages in the Inform Standard Rules will print even if the NPC they mention is not visibile to the player.
+
+See this discussion about other glitches that may occur when NPC actions fail, and some ideas on what to do about it: https://intfiction.org/t/postures-by-emily-short/6748/6
 
 Section: Change Log
 

--- a/Emily Short/Postures.i7x
+++ b/Emily Short/Postures.i7x
@@ -173,22 +173,22 @@ Instead of an actor standing up (this is the convert standing up rule):
 
 Section 6 - Disambiguating Postures
 
-Does the player mean sitting on something when the posture of the noun is seated (this is the prefer sitting on seating objects rule):
+Does the player mean sitting on something when the noun is enterable and the posture of the noun is seated (this is the prefer sitting on seating objects rule):
 	it is very likely.
 
-Does the player mean standing up on something when the posture of the noun is standing (this is the prefer standing on standing objects rule):
+Does the player mean standing up on something when the noun is enterable and the posture of the noun is standing (this is the prefer standing on standing objects rule):
 	it is very likely.
 
-Does the player mean lying on something when the posture of the noun is reclining (this is the prefer lying on reclining objects rule):
+Does the player mean lying on something when the noun is enterable and the posture of the noun is reclining (this is the prefer lying on reclining objects rule):
 	it is very likely.
 
-Does the player mean asking someone to try sitting on something when the posture of the noun is seated (this is the prefer request sitting on seating objects rule):
+Does the player mean asking someone to try sitting on something when the noun is enterable and the posture of the noun is seated (this is the prefer request sitting on seating objects rule):
 	it is very likely.
 
-Does the player mean asking someone to try standing up on something when the posture of the noun is standing (this is the prefer request standing on standing objects rule):
+Does the player mean asking someone to try standing up on something when the noun is enterable and the posture of the noun is standing (this is the prefer request standing on standing objects rule):
 	it is very likely.
 
-Does the player mean asking someone to try lying on something when the posture of the noun is reclining (this is the prefer request lying on reclining objects rule):
+Does the player mean asking someone to try lying on something when the the noun is enterable and posture of the noun is reclining (this is the prefer request lying on reclining objects rule):
 	it is very likely.
 
 Section 7 - Taking Position Action

--- a/Emily Short/Postures.i7x
+++ b/Emily Short/Postures.i7x
@@ -23,7 +23,9 @@ Section 4 - Sitting, Lying, and Standing On Commands
 Understand the commands "stand" and "sit" and "lie" as something new.
 
 Understand "sit on/in [something]" as sitting on.
+Understand "sit down on/in [something]" as sitting on.
 Understand "lie on/in [something]" as lying on.
+Understand "lie down on/in [something]" as lying on.
 Understand "stand on/in [something]" as standing up on.
 
 Sitting on is an action applying to one thing.

--- a/Emily Short/Postures.i7x
+++ b/Emily Short/Postures.i7x
@@ -47,7 +47,7 @@ Carry out an actor sitting on (this is the standard carry out sitting on rule):
 					follow the report taking position rules;
 		otherwise:
 			if the actor is visible:
-				say "[The actor] can't sit on [the noun].";
+				say "[The actor] [can't] sit on [the noun].";
 
 Carry out an actor lying on (this is the standard carry out lying on rule):
 	if the holder of the actor is the noun:
@@ -66,7 +66,7 @@ Carry out an actor lying on (this is the standard carry out lying on rule):
 					follow the report taking position rules;
 		otherwise:
 			if the actor is visible:
-				say "[The actor] can't lie on [the noun].";
+				say "[The actor] [can't] lie on [the noun].";
 
 Carry out an actor standing up on (this is the standard carry out standing up on rule):
 	if the holder of the actor is the noun:
@@ -85,7 +85,7 @@ Carry out an actor standing up on (this is the standard carry out standing up on
 					follow the report taking position rules;
 		otherwise:
 			if the actor is visible:
-				say "[The actor] can't stand on [the noun].";
+				say "[The actor] [can't] stand on [the noun].";
 
 Section 5 - Sitting, Lying, and Standing with Default Objects
 
@@ -119,9 +119,9 @@ Instead of an actor lying down (this is the convert lying down rule):
 	otherwise:
 		if the actor is visible:
 			if the holder of the actor is a thing:
-				say "[The actor] can't lie down on [the holder of the actor].";
+				say "[The actor] [can't] lie down on [the holder of the actor].";
 			otherwise:
-				say "There's nothing here to lie on.";
+				say "There [are] nothing [here] to lie on.";
 		rule succeeds.
 
 To decide whether (N - a person) can sit here:
@@ -146,9 +146,9 @@ Instead of an actor sitting down (this is the convert sitting down rule):
 	otherwise:
 		if the actor is visible:
 			if the holder of the actor is a thing:
-				say "[The actor] can't sit down on [the holder of the actor].";
+				say "[The actor] [can't] sit down on [the holder of the actor].";
 			otherwise:
-				say "There's nothing here to sit on.";
+				say "There [are] nothing [here] to sit on.";
 		rule succeeds.
 
 Instead of an actor standing up (this is the convert standing up rule):
@@ -198,7 +198,7 @@ Taking position is an action applying to one posture.
 Check an actor taking position (this is the can't use inappropriate postures rule):
 	if the holder of the actor is not a room and the holder of the actor does not allow the posture understood:
 		if the actor is visible:
-			say "[The actor] can't take that position [in-on the holder of the actor].";
+			say "[The actor] [can't] take that position [in-on the holder of the actor].";
 		stop the action.
 
 Check an actor taking position (this is the can't use already used posture rule):

--- a/Emily Short/Postures.i7x
+++ b/Emily Short/Postures.i7x
@@ -1,6 +1,6 @@
-Postures by Emily Short begins here.
+Version 2/180528 of Postures by Emily Short begins here.
 
-"Postures defines three postures -- seated, standing, and reclining -- and allows pieces of furniture to specify which postures are possible and preferred when the player is on those furnishings." 
+"Postures defines three postures -- seated, standing, and reclining -- and allows pieces of furniture to specify which postures are possible and preferred when the player is on those furnishings."
 
 Section 1 - The Concenpt
 
@@ -31,28 +31,67 @@ Lying on is an action applying to one thing.
 Standing up on is an action applying to one thing.
 
 Carry out an actor sitting on (this is the standard carry out sitting on rule):
-	if the holder of the actor is not the noun, silently try the actor entering the noun;
 	if the holder of the actor is the noun:
-		if the actor is not seated, try the actor taking position seated;
-		otherwise follow the report taking position rules.
+		if the actor is seated:
+			if the actor is visible:
+				say "[The actor] [are] already sitting on [the noun].";
+		otherwise:
+			try the actor taking position seated;
+	otherwise:
+		if the noun allows seated:
+			silently try the actor entering the noun;
+			if the holder of the actor is the noun:
+				if the actor is not seated:
+					try the actor taking position seated;
+				otherwise:
+					follow the report taking position rules;
+		otherwise:
+			if the actor is visible:
+				say "[The actor] can't sit on [the noun].";
 
 Carry out an actor lying on (this is the standard carry out lying on rule):
-	if the holder of the actor is not the noun, silently try the actor entering the noun;
 	if the holder of the actor is the noun:
-		if the actor is not reclining, try the actor taking position reclining;
-		otherwise follow the report taking position rules.
+		if the actor is reclining:
+			if the actor is visible:
+				say "[The actor] [are] already reclining on [the noun].";
+		otherwise:
+			try the actor taking position reclining;
+	otherwise:
+		if the noun allows reclining:
+			silently try the actor	entering the noun;
+			if the holder of the actor is the noun:
+				if the actor is not reclining:
+					try the actor taking position reclining;
+				otherwise:
+					follow the report taking position rules;
+		otherwise:
+			if the actor is visible:
+				say "[The actor] can't lie on [the noun].";
 
 Carry out an actor standing up on (this is the standard carry out standing up on rule):
-	if the holder of the actor is not the noun, silently try the actor entering the noun;
 	if the holder of the actor is the noun:
-		if the actor is not standing, try the actor taking position standing;
-		otherwise follow the report taking position rules.
+		if the actor is standing:
+			if the actor is visible:
+				say "[The actor] [are] already standing on [the noun].";
+		otherwise:
+			try the actor taking position standing;
+	otherwise:
+		if the noun allows standing:
+			silently try the actor entering the noun;
+			if the holder of the actor is the noun:
+				if the actor is not standing:
+					try the actor taking position standing;
+				otherwise:
+					follow the report taking position rules;
+		otherwise:
+			if the actor is visible:
+				say "[The actor] can't stand on [the noun].";
 
 Section 5 - Sitting, Lying, and Standing with Default Objects
 
-Understand "lie down" as lying down.
+Understand "lie down" or "lie" as lying down.
 Understand "sit down" or "sit" or "sit up" as sitting down.
-Understand "stand" or "stand up" as standing up. 
+Understand "stand" or "stand up" as standing up.
 
 Lying down is an action applying to nothing.
 Sitting down is an action applying to nothing.
@@ -64,27 +103,26 @@ To decide whether (N - a person) can lie here:
 	if the location of N is posture-friendly:
 		yes;
 	no.
-	
+
 Instead of an actor lying down (this is the convert lying down rule):
-	if the actor can lie here:
-		try the actor taking position reclining; 
-		if the posture of the actor is reclining:
-			rule succeeds;
-		rule fails;
-	otherwise if the holder of the actor contains something (called target) which allows reclining:
+	if the holder of the actor contains something (called target) which allows reclining:
 		if the holder of the actor contains an enterable reclining thing (called the better target):
 			now the target is the better target;
 		try the actor lying on the target;
 		if the posture of the actor is reclining and the actor is on the target:
 			rule succeeds;
 		rule fails;
+	if the actor can lie here:
+		try the actor taking position reclining;
+		if the posture of the actor is reclining:
+			rule succeeds;
 	otherwise:
-		if the player is the actor:
+		if the actor is visible:
 			if the holder of the actor is a thing:
-				say "You can't lie down on [the holder of the actor].";
+				say "[The actor] can't lie down on [the holder of the actor].";
 			otherwise:
-				say "There's nothing to lie on.";
-		rule fails.
+				say "There's nothing here to lie on.";
+		rule succeeds.
 
 To decide whether (N - a person) can sit here:
 	if the holder of N is a thing and the holder of N allows seated:
@@ -94,45 +132,42 @@ To decide whether (N - a person) can sit here:
 	no.
 
 Instead of an actor sitting down (this is the convert sitting down rule):
-	if the actor can sit here:
-		try the actor taking position seated; 
-		if the posture of the actor is seated:
-			rule succeeds;
-		rule fails;
-	otherwise if the holder of the actor contains something (called target) which allows seated:
+	if the holder of the actor contains something enterable (called target) which allows seated:
 		if the holder of the actor contains an enterable seated thing (called the better target):
 			now the target is the better target;
 		try the actor sitting on the target;
 		if the posture of the actor is seated and the actor is on the target:
 			rule succeeds;
 		rule fails;
+	if the actor can sit here:
+		try the actor taking position seated;
+		if the posture of the actor is seated:
+			rule succeeds;
 	otherwise:
-		if the player is the actor:
+		if the actor is visible:
 			if the holder of the actor is a thing:
-				say "You can't sit down on [the holder of the actor].";
+				say "[The actor] can't sit down on [the holder of the actor].";
 			otherwise:
-				say "There's nothing to sit on.";
-		rule fails.
+				say "There's nothing here to sit on.";
+		rule succeeds.
 
 Instead of an actor standing up (this is the convert standing up rule):
-	if the holder of the actor is a thing and the holder of the actor allows standing:
-		try the actor taking position standing; 
+	let the source be the holder of the actor;
+	if the source is not the location:
+		if the posture of the actor is standing:
+			if the actor is visible:
+				say "[The actor] [are] already standing.";
+			the rule succeeds;
+		otherwise:
+			try the actor exiting;
+			if the holder of the actor is the source:
+				rule fails;
+		rule succeeds;
+	otherwise:
+		try the actor taking position standing;
 		if the posture of the actor is standing:
 			rule succeeds;
 		rule fails;
-	otherwise if the holder of the actor is not the location:
-		let the source be the holder of the actor;
-		try the actor exiting;
-		if the holder of the actor is the source:
-			rule fails;
-		rule succeeds;
-	otherwise:
-		if the player is the actor:
-			if the holder of the actor is a thing:
-				say "You can't lie down on [the holder of the actor].";
-			otherwise:
-				say "There's nothing to stand on.";
-		rule fails.
 
 Section 6 - Disambiguating Postures
 
@@ -162,28 +197,22 @@ Taking position is an action applying to one posture.
 
 Check an actor taking position (this is the can't use inappropriate postures rule):
 	if the holder of the actor is not a room and the holder of the actor does not allow the posture understood:
-		if the actor is the player:
-			say "You can't take that position [in-on the holder of the actor].";
-		otherwise if the actor is visible:
-			say "[The actor] can't take that position.";
+		if the actor is visible:
+			say "[The actor] can't take that position [in-on the holder of the actor].";
 		stop the action.
 
 Check an actor taking position (this is the can't use already used posture rule):
 	if the posture understood is the posture of the actor:
-		if the actor is the player:
-			say "You are already [the posture understood].";
-		otherwise:
-			if the actor is visible, say "[The actor] is already [the posture understood].";
+		if the actor is visible:
+			say "[The actor] [are] already [the posture understood].";
 		stop the action.
 
 Carry out an actor taking position (this is the standard taking position rule):
 	now the posture of the actor is the posture understood.
 
-Report someone taking position (this is the stranger position report rule rule):
-	say "[The actor] is now [the posture of the actor][if the holder of the actor is not the location of the actor] [in-on the holder of the actor][end if]."
-
-Report taking position (this is the standard position report rule):
-	say "You are now [the posture of the player][if the holder of the player is not the location] [in-on the holder of the player][end if]."
+Report an actor taking position (this is the standard position report rule):
+	if the actor is visible:
+		say "[The actor] [are] now [the posture of the actor][if the holder of the actor is not the location of the actor] [in-on the holder of the actor][end if]."
 
 To say in-on (item - a thing):
 	if the item is a container, say "in [the item]";
@@ -208,7 +237,8 @@ The arrival-posture rule is listed after the standard entering rule in the carry
 
 Check an actor going somewhere (this is the can't go without standing rule):
 	if the actor is in a room and the actor is not standing:
-		say "([if the actor is not the player][the actor] [end if]first standing up)[command clarification break]";
+		if the actor is visible:
+			say "([if the actor is not the player][the actor] [end if]first standing up)[command clarification break]";
 		silently try the actor taking position standing;
 		if the actor is not standing, stop the action.
 
@@ -231,11 +261,13 @@ Each piece of furniture comes with a range of possible postures, which can be ex
 
 	The bunk bed allows seated and reclining.
 
-This definition would say that we're allowed to sit or lie down on the bunk bed, but not to stand up on it. Player attempts to 
+This definition would say that we're allowed to sit or lie down on the bunk bed, but not to stand up on it. Player attempts to
 
 	>STAND ON BUNK BED
 
 will be rejected with
+
+	You can't take that position on the bunk bed.
 
 Section: Preferred Postures
 
@@ -267,7 +299,13 @@ This feature determines whether a player can take postures other than standing w
 
 	>LIE DOWN
 
-without naming where he wants to lie down. If the room is posture-friendly, he will lie down in the location. If it's posture-unfriendly, the game will look for an available piece of furniture that allows reclining (ideally one whose preferred posture is reclining) and try to lie on that, instead.
+without naming where he wants to lie down. The game will first look for an available piece of furniture that allows reclining (ideally one whose preferred posture is reclining) and try to lie on that, but if it finds none and the room is posture-friendly, the player will lie down on the floor. If the room is posture-unfriendly and there is no suitable piece of furniture, the game will be rejected with
+
+	There's nothing to lie on.
+
+Section: Change Log
+
+Version 2/180527 fixes a run-time error that could occur when typing LIE. It also always looks for a reasonable piece of furniture to sit or lie down on in a room rather than defaulting to the floor when typing just SIT or LIE, even if the room is posture-friendly.
 
 Example: * Muddy Lawn - A room where the player can't sit on the ground, plus a folding chair, a safer-to-sit-on driveway, and the ubiquitous guinea-pig Clark.
 

--- a/Emily Short/Postures.i7x
+++ b/Emily Short/Postures.i7x
@@ -2,6 +2,10 @@ Version 2/180528 of Postures by Emily Short begins here.
 
 "Postures defines three postures -- seated, standing, and reclining -- and allows pieces of furniture to specify which postures are possible and preferred when the player is on those furnishings."
 
+Chapter - Miscellaneous Definitions
+
+Use posture visibility checks translates as (- Constant POSTURE_VISIBILITY_CHECKS; -).
+
 Section 1 - The Concenpt
 
 A posture is a kind of value. The postures are seated, standing, and reclining.
@@ -35,7 +39,7 @@ Standing up on is an action applying to one thing.
 Carry out an actor sitting on (this is the standard carry out sitting on rule):
 	if the holder of the actor is the noun:
 		if the actor is seated:
-			if the actor is visible:
+			unless the posture visibility checks option is active and the actor is not visible:
 				say "[The actor] [are] already sitting on [the noun].";
 		otherwise:
 			try the actor taking position seated;
@@ -48,13 +52,13 @@ Carry out an actor sitting on (this is the standard carry out sitting on rule):
 				otherwise:
 					follow the report taking position rules;
 		otherwise:
-			if the actor is visible:
+			unless the posture visibility checks option is active and the actor is not visible:
 				say "[The actor] [can't] sit on [the noun].";
 
 Carry out an actor lying on (this is the standard carry out lying on rule):
 	if the holder of the actor is the noun:
 		if the actor is reclining:
-			if the actor is visible:
+			unless the posture visibility checks option is active and the actor is not visible:
 				say "[The actor] [are] already reclining on [the noun].";
 		otherwise:
 			try the actor taking position reclining;
@@ -67,13 +71,13 @@ Carry out an actor lying on (this is the standard carry out lying on rule):
 				otherwise:
 					follow the report taking position rules;
 		otherwise:
-			if the actor is visible:
+			unless the posture visibility checks option is active and the actor is not visible:
 				say "[The actor] [can't] lie on [the noun].";
 
 Carry out an actor standing up on (this is the standard carry out standing up on rule):
 	if the holder of the actor is the noun:
 		if the actor is standing:
-			if the actor is visible:
+			unless the posture visibility checks option is active and the actor is not visible:
 				say "[The actor] [are] already standing on [the noun].";
 		otherwise:
 			try the actor taking position standing;
@@ -86,7 +90,7 @@ Carry out an actor standing up on (this is the standard carry out standing up on
 				otherwise:
 					follow the report taking position rules;
 		otherwise:
-			if the actor is visible:
+			unless the posture visibility checks option is active and the actor is not visible:
 				say "[The actor] [can't] stand on [the noun].";
 
 Section 5 - Sitting, Lying, and Standing with Default Objects
@@ -119,7 +123,7 @@ Instead of an actor lying down (this is the convert lying down rule):
 		if the posture of the actor is reclining:
 			rule succeeds;
 	otherwise:
-		if the actor is visible:
+		unless the posture visibility checks option is active and the actor is not visible:
 			if the holder of the actor is a thing:
 				say "[The actor] [can't] lie down on [the holder of the actor].";
 			otherwise:
@@ -146,7 +150,7 @@ Instead of an actor sitting down (this is the convert sitting down rule):
 		if the posture of the actor is seated:
 			rule succeeds;
 	otherwise:
-		if the actor is visible:
+		unless the posture visibility checks option is active and the actor is not visible:
 			if the holder of the actor is a thing:
 				say "[The actor] [can't] sit down on [the holder of the actor].";
 			otherwise:
@@ -157,7 +161,7 @@ Instead of an actor standing up (this is the convert standing up rule):
 	let the source be the holder of the actor;
 	if the source is not the location:
 		if the posture of the actor is standing:
-			if the actor is visible:
+			unless the posture visibility checks option is active and the actor is not visible:
 				say "[The actor] [are] already standing.";
 			the rule succeeds;
 		otherwise:
@@ -199,13 +203,13 @@ Taking position is an action applying to one posture.
 
 Check an actor taking position (this is the can't use inappropriate postures rule):
 	if the holder of the actor is not a room and the holder of the actor does not allow the posture understood:
-		if the actor is visible:
+		unless the posture visibility checks option is active and the actor is not visible:
 			say "[The actor] [can't] take that position [in-on the holder of the actor].";
 		stop the action.
 
 Check an actor taking position (this is the can't use already used posture rule):
 	if the posture understood is the posture of the actor:
-		if the actor is visible:
+		unless the posture visibility checks option is active and the actor is not visible:
 			say "[The actor] [are] already [the posture understood].";
 		stop the action.
 
@@ -213,7 +217,7 @@ Carry out an actor taking position (this is the standard taking position rule):
 	now the posture of the actor is the posture understood.
 
 Report an actor taking position (this is the standard position report rule):
-	if the actor is visible:
+	unless the posture visibility checks option is active and the actor is not visible:
 		say "[The actor] [are] now [the posture of the actor][if the holder of the actor is not the location of the actor] [in-on the holder of the actor][end if]."
 
 To say in-on (item - a thing):
@@ -239,7 +243,7 @@ The arrival-posture rule is listed after the standard entering rule in the carry
 
 Check an actor going somewhere (this is the can't go without standing rule):
 	if the actor is in a room and the actor is not standing:
-		if the actor is visible:
+		unless the posture visibility checks option is active and the actor is not visible:
 			say "([if the actor is not the player][the actor] [end if]first standing up)[command clarification break]";
 		silently try the actor taking position standing;
 		if the actor is not standing, stop the action.
@@ -305,15 +309,25 @@ without naming where he wants to lie down. The game will first look for an avail
 
 	There's nothing to lie on.
 
+Section: The Posture Visibility Checks option
+
+Before printing an error message for an NPC, such as "Clark is already sitting" when Clark is trying to sit, this extension can first check whether the player can actually see Clark. If he is in another room or in a closed opaque container, no message will be printed. As visibility checks in Inform can sometimes be slow, this feature is off by default, but can be turned on with the line
+
+	Use posture visibility checks.
+
+Note that this only applies to the new messages introduced by this extension. Many error messages in the Inform Standard Rules will print even if the NPC they mention is not visibile to the player.
+
 Section: Change Log
 
-Version 2/180527 fixes a run-time error that could occur when typing LIE. It also always looks for a reasonable piece of furniture to sit or lie down on in a room rather than defaulting to the floor when typing just SIT or LIE, even if the room is posture-friendly.
+Version 2/180528 fixes a run-time error that could occur when typing LIE. It also always looks for a reasonable piece of furniture to sit or lie down on in a room rather than defaulting to the floor when typing just SIT or LIE, even if the room is posture-friendly. It also introduces the posture visibility checks option
 
 Example: * Muddy Lawn - A room where the player can't sit on the ground, plus a folding chair, a safer-to-sit-on driveway, and the ubiquitous guinea-pig Clark.
 
 	*: "Muddy Lawn"
 
 	Include Postures by Emily Short.
+
+	Use posture visibility checks.
 
 	A chair is a kind of supporter. A chair is always enterable. Every chair allows seated and standing. A chair is usually seated.
 


### PR DESCRIPTION
At the moment, this feels a little unpolished and so is mainly a request for comments. It is an updated version of the Postures extension, based on my work with [Counterfeit Monkey](https://github.com/i7/counterfeit-monkey).

I'm not sure what the best way is to handle responses about actions taken by NPC:s. More or less every message printed in the current code is preceded by checking "if the actor is visible," which doesn't seem very elegant and could potentially be slow. In the standard rules, the more common check seems to be "if the actor is the player" and then printing nothing if the actor isn't. 

But I think it is nice to get a more detailed response, such as "Clark is already standing on the folding chair," rather than just "Clark is unable to do that," and all those "if the actor is visible" seem to be the simplest way to achieve that without having to write a lot of separate rules just to print basically the same response.

The "convert lying down rule," "convert sitting down rule" and "convert standing up rule" used to end with success or failure, but I've found that if I print a failure message such as "There [are] nothing [here] to sit on," I have to return success, otherwise there will be a second response printed:

```
>Clark, sit
There is nothing here to sit on.

Clark is unable to do that.
```

This means that the rules will now always end in success, which makes all those "rule succeeds" lines a little redundant.


