### PR TITLE
initial commit of informant (and docs dir itself)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,2701 @@
+<!doctype html>
+<html lang="en"><head><meta charset="UTF-8"><title>Friends of I7 Extensions</title>
+<style>* { padding: 0; margin: 0 ; }
+html { font-size: 100%; }
+body { 
+color: #080808; 
+background-color: #FAFAFA;
+color: #0A0A0A;
+width: 41.5rem;
+margin: auto;
+font-size: 100%;
+margin-bottom: 2rem;
+} 
+h1.title { text-align: center; font-family: Constantia,Lucida Bright,Lucidabright,"Lucida Serif",Lucida,"DejaVu Serif","Bitstream Vera Serif","Liberation Serif",Georgia,serif; margin-top: 1rem; margin-bottom: 2rem; }
+div.ext-table { line-height: 1.5; font-family: Helvetica Neue,Helvetica,Arial,sans-serif; width: 40rem; margin-bottom: 2rem; }
+a.title { text-decoration-style: dotted; }
+div.ext-table-body { }
+hr.border { border: .05rem solid #333; margin: 1rem .5rem 1rem -1.5rem; }
+div.ext-name {  white-space: nowrap; width: 100%; margin-top: .1rem; font-size: 1.25rem; text-indent: -1.5rem; }
+div.ext-desc { margin-bottom: .5rem; padding-top: .25rem; }
+div.empty-desc { text-align: right; margin-right: .5rem; }
+a.ext { }
+span.link { font-weight: bold;} 
+span.version { font-size: 1rem; }
+span.limiter { font-style: italic; font-size: 1rem; }
+span.code { font-family: monospace; }
+div.error { margin-left: -1.5rem; }
+h2 { margin-top: 1rem; margin-bottom: 1rem; }
+details { border: .1rem solid black; padding: .5rem; }
+summary { margin: .5rem 0 .5rem 0; }
+p.omission { margin-bottom: .5rem; }
+</style>
+</head>
+<body><main>
+<h1 class="title"><a class="title" href="">Friends of I7 Extensions</a></h1>
+<div class="ext-table">
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Friends%20of%20I7/6G60%20Patches.i7x"><span class='link'>6G60 Patches by Friends of I7</span></a>
+    &ensp;<span class="version">Version&nbsp;1</span>
+      </div>
+  <div class="ext-desc">Patches to work around bugs in version 6G60 of Inform 7 for which an extension-based workaround is known to exist.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Friends%20of%20I7/6L38%20Patches.i7x"><span class='link'>6L38 Patches by Friends of I7</span></a>
+    &ensp;<span class="version">Version&nbsp;1/150116</span>
+      </div>
+  <div class="ext-desc">Patches to work around bugs in version 6L38 of Inform 7 for which an extension-based workaround is known to exist.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Friends%20of%20I7/6M62%20Patches.i7x"><span class='link'>6M62 Patches by Friends of I7</span></a>
+      </div>
+  <div class="ext-desc empty-desc"><span class="code">(I see no description here.)</span></div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Juhana%20Leinonen/Achievements.i7x"><span class='link'>Achievements by Juhana Leinonen</span></a>
+    &ensp;<span class="version">Version&nbsp;1/151231</span>
+      </div>
+  <div class="ext-desc">A simple but flexible rule-based achievement system. Awarded achievements can optionally persist in external files after a restart.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Mikael%20Segercrantz/Achievements.i7x"><span class='link'>Achievements by Mikael Segercrantz</span></a>
+    &ensp;<span class="version">Version&nbsp;4/140513</span>
+      </div>
+  <div class="ext-desc">A table-based way to assign scores for actions, rooms and objects.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Matt%20Weiner/Actions%20on%20Groups.i7x"><span class='link'>Actions on Groups by Matt Weiner</span></a>
+      </div>
+  <div class="ext-desc">PURPOSE OF EXTENSION</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Eric%20Eve/Adaptive%20Hints.i7x"><span class='link'>Adaptive Hints by Eric Eve</span></a>
+    &ensp;<span class="version">Version&nbsp;7</span>
+      </div>
+  <div class="ext-desc">An adaptive hint system based on Menus by Emily Short.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Nels%20Olsen/Advanced%20Dungeons%20and%20Dragons%20Characters.i7x"><span class='link'>Advanced Dungeons and Dragons Characters by Nels Olsen</span></a>
+    &ensp;<span class="version">Version&nbsp;1/160118</span>
+      </div>
+  <div class="ext-desc">Provides rudimentary support for a party of old-school D&amp;D characters.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/John%20W%20Kennedy/Advanced%20Help%20Menu.i7x"><span class='link'>Advanced Help Menu by John W Kennedy</span></a>
+    &ensp;<span class="version">Version&nbsp;1/140513</span>
+      </div>
+  <div class="ext-desc">Builds on Emily Short&#39;s Basic Help Menu, with hints that are enabled under program control and sample transcriptions</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Edward%20Griffiths/Adventure%20Book.i7x"><span class='link'>Adventure Book by Edward Griffiths</span></a>
+    &ensp;<span class="version">Version&nbsp;1/140513</span>
+      </div>
+  <div class="ext-desc">A system for creating Choose Your Own Adventure style programs, with advanced features.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Ron%20Newcomb/After%20Not%20Doing%20Something.i7x"><span class='link'>After Not Doing Something by Ron Newcomb</span></a>
+    &ensp;<span class="version">Version&nbsp;2</span>
+      </div>
+  <div class="ext-desc">Allows us to write rules that happen after an action fails, such as &#39;After not examining or searching something&#39;</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Daniel%20Stelzer/Alternate%20Lighting%20System.i7x"><span class='link'>Alternate Lighting System by Daniel Stelzer</span></a>
+      </div>
+  <div class="ext-desc">This extension replaces the Inform 6 lighting code with an Inform 7 version. In essence, it replaces the condition &quot;object has light&quot; in the Inform 6 templates with a call to an Inform 7 rulebook. If you don&#39;t want the overhead for a particular object, you can declare it to be &quot;not specially lighted&quot;.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Dannii%20Willis/Alternative%20Startup%20Rules.i7x"><span class='link'>Alternative Startup Rules by Dannii Willis</span></a>
+    &ensp;<span class="version">Version&nbsp;1/140516</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Refactors the Startup Rules so that it can be more easily altered</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Eric%20Eve/Alternatives.i7x"><span class='link'>Alternatives by Eric Eve</span></a>
+    &ensp;<span class="version">Version&nbsp;3</span>
+      </div>
+  <div class="ext-desc">Allows checking the presence of an object or value in a set of objects or values with new either/or and neither/nor phrases. e.g., &#39;If the noun is either the carrot or the potato:&#39;, or &#39;Instead of eating something when the noun is neither the cake nor the pudding:&#39;</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Emily%20Short/Approaches.i7x"><span class='link'>Approaches by Emily Short</span></a>
+    &ensp;<span class="version">Version&nbsp;7</span>
+      </div>
+  <div class="ext-desc">Approaches provides a GO TO place action which allows the player to move through visited rooms to a new location. It also allows other characters to traverse the map to named locations. It is designed to work with Locksmith by Emily Short. Version 7 drops the erroneous requirement of the Plurality extension, which was still mentioned in Version 6.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Mike%20Ciul/Approximate%20Quantities.i7x"><span class='link'>Approximate Quantities by Mike Ciul</span></a>
+    &ensp;<span class="version">Version&nbsp;1</span>
+      </div>
+  <div class="ext-desc">A means to print numbers as &#39;a few&#39; or &#39;hundreds.&#39; Also provides a system of counting numbers which never go below 0 or above a specified maximum value. Any numbers above the maximum are considered infinite.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/David%20Ratliff/Armed.i7x"><span class='link'>Armed by David Ratliff</span></a>
+    &ensp;<span class="version">Version&nbsp;3/140513</span>
+      </div>
+  <div class="ext-desc">This is just a (no longer) little extension to handle weapons and fighting.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Daniel%20Stelzer/Article%20Bug%20Fix.i7x"><span class='link'>Article Bug Fix by Daniel Stelzer</span></a>
+      </div>
+  <div class="ext-desc">Fixes for two small bugs with indefinite articles.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Emily%20Short/Assorted%20Text%20Generation.i7x"><span class='link'>Assorted Text Generation by Emily Short</span></a>
+    &ensp;<span class="version">Version&nbsp;5</span>
+      </div>
+  <div class="ext-desc">Assorted Text Generation supplies routines for producing prose in various common situations.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Michael%20Martin/Assumed%20Conversers.i7x"><span class='link'>Assumed Conversers by Michael Martin</span></a>
+    &ensp;<span class="version">Version&nbsp;3/170621</span>
+      </div>
+  <div class="ext-desc">A minimal extension that makes the NPC optional in ASK NPC ABOUT TOPIC and TELL NPC ABOUT TOPIC commands.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Mikael%20Segercrantz/Atmospheric%20Effects.i7x"><span class='link'>Atmospheric Effects by Mikael Segercrantz</span></a>
+    &ensp;<span class="version">Version&nbsp;6/140513</span>
+      </div>
+  <div class="ext-desc">A table-based way to add atmospheric effects to rooms, regions, things and scenes.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Mark%20Tilford/Automap.i7x"><span class='link'>Automap by Mark Tilford</span></a>
+    &ensp;<span class="version">Version&nbsp;4/140513</span>
+      </div>
+  <div class="ext-desc">An extension to automatically draw a map.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Automap%20IT.i7x"><span class='link'>Automap IT by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;4/140823</span>
+      </div>
+  <div class="ext-desc">Translation in italian of Version 4/140513 of Automap by Mark Tilford. An extension to automatically draw a map.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Emily%20Short/Automated%20Drawers.i7x"><span class='link'>Automated Drawers by Emily Short</span></a>
+    &ensp;<span class="version">Version&nbsp;6</span>
+      </div>
+  <div class="ext-desc">Creates a drawer kind of container, which is designed to be part of an item of furniture. Automatically parses names such as &#39;top drawer&#39; or &#39;fourth drawer&#39; or &#39;left drawer&#39;; adds some features for describing furniture with drawers.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Daniel%20Stelzer/Autosave.i7x"><span class='link'>Autosave by Daniel Stelzer</span></a>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Allows the programmer to save and restore from an autosave file without the user being aware of it</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Mike%20Ciul/Autotaking.i7x"><span class='link'>Autotaking by Mike Ciul</span></a>
+      </div>
+  <div class="ext-desc">Implicit taking of noun or second noun that may be invoked by (or used as) a check rule.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Mike%20Ciul/Autoundo%20for%20Object%20Response%20Tests.i7x"><span class='link'>Autoundo for Object Response Tests by Mike Ciul</span></a>
+    &ensp;<span class="version">Version&nbsp;1</span>
+      </div>
+  <div class="ext-desc">Tests objects just like Juhana Leinonen&#39;s extension, but does an UNDO after each test.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/ShadowChaser/Basic%20Characters.i7x"><span class='link'>Basic Characters by ShadowChaser</span></a>
+    &ensp;<span class="version">Version&nbsp;1/140513</span>
+      </div>
+  <div class="ext-desc">This adds the properties health, magic and sanity to a person or animal. It allows these values to be progarmatically manipulated and includes a process that replenishes health and magic over time. It also provides commands and functions for obtaining a descriptive status of the condition of these three properties for any given person or animal.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/David%20Cornelson/Basic%20Help.i7x"><span class='link'>Basic Help by David Cornelson</span></a>
+    &ensp;<span class="version">Version&nbsp;1/140513</span>
+      </div>
+  <div class="ext-desc">This extension allows you to add basic Interactive Fiction help to your game.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Basic%20Help%20Hyperlinks.i7x"><span class='link'>Basic Help Hyperlinks by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;3/140811</span>
+      </div>
+  <div class="ext-desc">Define a command HELP that lists standard instructions accessible through hyperlinks. Based on Basic Help Menu by Emily Short.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Basic%20Help%20Hyperlinks%20IT.i7x"><span class='link'>Basic Help Hyperlinks IT by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;3/140811</span>
+      </div>
+  <div class="ext-desc">Fornisce un comando AIUTO che mostra un elenco con istruzioni standard attivabili mediante collegamenti ipertestuali.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Basic%20Help%20IT.i7x"><span class='link'>Basic Help IT by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;3/140811</span>
+      </div>
+  <div class="ext-desc">Fornisce un comando AIUTO che mostra un elenco con istruzioni standard attivabili mediante collegamenti ipertestuali.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Wade%20Clarke/Basic%20Help%20Menu.i7x"><span class='link'>Basic Help Menu by Wade Clarke</span></a>
+    &ensp;<span class="version">Version&nbsp;4</span>
+      </div>
+  <div class="ext-desc">Adds a HELP command to your Glulx or Z-Code project for Inform 6M62 or later which brings up a menu giving some standard instructions about IF. This is a tech and content update of Emily Short&#39;s Basic Help Menu extension made for compatibility with Wade Clarke&#39;s Menus. Requires Menus by Wade Clarke (version 5 or greater) to run.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Basic%20Help%20Menu%20IT.i7x"><span class='link'>Basic Help Menu IT by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;2</span>
+      </div>
+  <div class="ext-desc">Fornisce un comando AIUTO che mostra un menù con istruzioni standard. Semplicemente tradotto in italiano.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Emily%20Short/Basic%20Hyperlinks.i7x"><span class='link'>Basic Hyperlinks by Emily Short</span></a>
+    &ensp;<span class="version">Version&nbsp;3/140513</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Allows the author to set hyperlinks in the main window and give instructions about what is to result from performing them.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Bart%20Massey/Basic%20Literacy.i7x"><span class='link'>Basic Literacy by Bart Massey</span></a>
+    &ensp;<span class="version">Version&nbsp;2.1</span>
+      </div>
+  <div class="ext-desc">Provides objects and actions for (proper) reading, writing and erasing.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Nate%20Cull/Basic%20Plans.i7x"><span class='link'>Basic Plans by Nate Cull</span></a>
+    &ensp;<span class="version">Version&nbsp;3/140513</span>
+      </div>
+  <div class="ext-desc">A library of basic relations, actions and plans for Planner.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Sarah%20Morayati/Basic%20Real%20Time.i7x"><span class='link'>Basic Real Time by Sarah Morayati</span></a>
+    &ensp;<span class="version">Version&nbsp;2/140513</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Allows the author to incorporate Glulx real time events into an 
+Inform 7 project.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Dannii%20Willis/Benchmarking.i7x"><span class='link'>Benchmarking by Dannii Willis</span></a>
+    &ensp;<span class="version">Version&nbsp;1/130803</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">A general purpose benchmarking test framework that produces statistically significant results.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Dannii%20Willis/Better%20Flex.i7x"><span class='link'>Better Flex by Dannii Willis</span></a>
+    &ensp;<span class="version">Version&nbsp;1/190924</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Better performance for the Flex/Block value systems using Glulx&#39;s native malloc features</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Daniel%20Stelzer/Boolean%20Variables.i7x"><span class='link'>Boolean Variables by Daniel Stelzer</span></a>
+      </div>
+  <div class="ext-desc empty-desc"><span class="code">(I see no description here.)</span></div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Gavin%20Lambert/Brief%20Room%20Descriptions.i7x"><span class='link'>Brief Room Descriptions by Gavin Lambert</span></a>
+    &ensp;<span class="version">Version&nbsp;1/200926</span>
+      </div>
+  <div class="ext-desc">Alters BRIEF mode to display a room&#39;s brief description instead of nothing.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Eric%20Eve/Bulk%20Limiter.i7x"><span class='link'>Bulk Limiter by Eric Eve</span></a>
+    &ensp;<span class="version">Version&nbsp;9</span>
+      </div>
+  <div class="ext-desc">Containers and actors that limit their contents by bulk</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Bulk%20Limiter%20IT.i7x"><span class='link'>Bulk Limiter IT by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;9/140530</span>
+      </div>
+  <div class="ext-desc">Translation in italian of Version 9 of Bulk Limiter by Eric Eve.
+
+Containers and actors that limit their contents by bulk</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Juhana%20Leinonen/Bulky%20Items.i7x"><span class='link'>Bulky Items by Juhana Leinonen</span></a>
+    &ensp;<span class="version">Version&nbsp;3</span>
+      </div>
+  <div class="ext-desc">Bulky items that can be carried only if the player is not carrying anything else.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Bulky%20Items%20IT.i7x"><span class='link'>Bulky Items IT by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;2</span>
+      </div>
+  <div class="ext-desc">Basato sull&#39;espansione Version 2 of Bulky Items by Juhana Leinonen.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Nathanael%20Nerode/Character%20Portraits.i7x"><span class='link'>Character Portraits by Nathanael Nerode</span></a>
+    &ensp;<span class="version">Version&nbsp;1/171007</span>
+      </div>
+  <div class="ext-desc">Provides a complex system for customzing the printed descriptions of characters wearing or carrying lots of stuff, similar to the room description system in Standard Rules.  Requires Large Game Speedup by Nathanael Nerode.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Peter%20Orme/Checkpoints.i7x"><span class='link'>Checkpoints by Peter Orme</span></a>
+    &ensp;<span class="version">Version&nbsp;1/150130</span>
+      </div>
+  <div class="ext-desc">A method of using assertions stored in a table to verify your game works as expected.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Daniel%20Stelzer/Cleared%20Events.i7x"><span class='link'>Cleared Events by Daniel Stelzer</span></a>
+      </div>
+  <div class="ext-desc">This is a very simple extension, adding only a single phrase.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Brian%20Rushton/Clues%20and%20Conversation.i7x"><span class='link'>Clues and Conversation by Brian Rushton</span></a>
+    &ensp;<span class="version">Version&nbsp;5</span>
+      </div>
+  <div class="ext-desc">A simple system for building conversations.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Daniel%20Stelzer/Command%20Casing.i7x"><span class='link'>Command Casing by Daniel Stelzer</span></a>
+      </div>
+  <div class="ext-desc">A simple fix to preserve casing when the player&#39;s command is altered.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Command%20Line.i7x"><span class='link'>Command Line by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;2/140731</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Provides a command line in the bottom part of the screen, in which the player finds the most common commands. Glulx only.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Command%20Line%20IT.i7x"><span class='link'>Command Line IT by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;2/140728</span>
+      </div>
+  <div class="ext-desc">Translation in italian of Version 2/140728 of Command Line by Leonardo Boselli. Provides a command line in the bottom part of the screen, in which the player finds the most common commands. Glulx only.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Daniel%20Stelzer/Command%20Modification.i7x"><span class='link'>Command Modification by Daniel Stelzer</span></a>
+      </div>
+  <div class="ext-desc">This extension allows the programmer to override what the player typed and parse different commands instead.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Daniel%20Stelzer/Command%20Preloading.i7x"><span class='link'>Command Preloading by Daniel Stelzer</span></a>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">A simple way to preload input onto the command line before the player begins to type.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Ron%20Newcomb/Command%20Prompt%20on%20Cue.i7x"><span class='link'>Command Prompt on Cue by Ron Newcomb</span></a>
+    &ensp;<span class="version">Version&nbsp;3/140513</span>
+      </div>
+  <div class="ext-desc">Creates a situation without a command prompt where the player may simply press space or enter to WAIT.  But if the player instead begins to type a command, the command prompt will then appear.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Xavid/Command%20Unit%20Testing.i7x"><span class='link'>Command Unit Testing by Xavid</span></a>
+      </div>
+  <div class="ext-desc">Support for creating &#39;unit tests&#39; that run a series of commands and make assertions about the output of some of them.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Alice%20Grove/Common%20Commands%20Sidebar.i7x"><span class='link'>Common Commands Sidebar by Alice Grove</span></a>
+    &ensp;<span class="version">Version&nbsp;2/161024</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Displays a list of common parser commands in a sidebar as a reference for novice players. Includes actions to turn the sidebar off and on. Story author can tailor the command list and the appearance of the sidebar, or just plug and play. For version 6L or 6M of Inform 7.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Aaron%20Reed/Commonly%20Unimplemented.i7x"><span class='link'>Commonly Unimplemented by Aaron Reed</span></a>
+    &ensp;<span class="version">Version&nbsp;2</span>
+      </div>
+  <div class="ext-desc">Responds to attempts to interact with unimplemented clothing, body parts, or generic surroundings. Requires Smarter Parser by Aaron Reed.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Nathanael%20Nerode/Compliant%20Characters.i7x"><span class='link'>Compliant Characters by Nathanael Nerode</span></a>
+    &ensp;<span class="version">Version&nbsp;2/171007</span>
+      </div>
+  <div class="ext-desc">Report parsing errors to the player when ordering other characters to do things.  Inform 7 normally redirects these errors to &#39;answer &lt;topic&gt;&#39; so that the character can respond to arbitrary statements.  But in an story with compliant characters who the player orders around routinely, that is frustrating to a player who has made a typo; this helps out the player.  Requires Parser Error Number Bugfix and version 4 of Neutral Standard Responses.  Tested with Inform 6M62.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Emily%20Short/Computers.i7x"><span class='link'>Computers by Emily Short</span></a>
+    &ensp;<span class="version">Version&nbsp;8/160611</span>
+      </div>
+  <div class="ext-desc">Computer hardware and software, including search engines and email programs. Version 3 adds handling for batteries and cords, if we include Power Sources by Emily Short (which itself depends on Plugs and Sockets by Sean Turner).</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Mike%20Ciul/Conditional%20Backdrops.i7x"><span class='link'>Conditional Backdrops by Mike Ciul</span></a>
+    &ensp;<span class="version">Version&nbsp;3/111020</span>
+      </div>
+  <div class="ext-desc">An extension to allow a single rulebook to determine the presence of multiple backdrops.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Creative%20Commons/Configurable%20Creative%20Commons%20License.i7x"><span class='link'>Configurable Creative Commons License by Creative Commons</span></a>
+    &ensp;<span class="version">Version&nbsp;1/101023</span>
+      </div>
+  <div class="ext-desc">Allows easy implementation of a Creative Commons Public License of the author&#39;s choice.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Configurable%20Creative%20Commons%20License.i7x"><span class='link'>Configurable Creative Commons License by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;1/140818</span>
+      </div>
+  <div class="ext-desc">Allows easy implementation of a Creative Commons Public License of the author&#39;s choice. Modified from Version 1/101023 of Configurable Creative Commons License by Creative Commons for 6L02 compliance.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Configurable%20Creative%20Commons%20License%20IT.i7x"><span class='link'>Configurable Creative Commons License IT by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;1/140818</span>
+      </div>
+  <div class="ext-desc">Allows easy implementation of a Creative Commons Public License of the author&#39;s choice. Modified from Version 1/101023 of Configurable Creative Commons License by Creative Commons for 6L02 compliance.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/John%20Clemens/Consolidated%20Multiple%20Actions.i7x"><span class='link'>Consolidated Multiple Actions by John Clemens</span></a>
+    &ensp;<span class="version">Version&nbsp;3</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">An extension to consolidate action reports when performing an action on multiple objects, such as with &#39;take all&#39;. Requires Hypothetical Questions by Jesse McGrew. Version 3 updated by Emily Short for 6L38 compatibility.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/David%20Corbett/Constraint%20Solver.i7x"><span class='link'>Constraint Solver by David Corbett</span></a>
+      </div>
+  <div class="ext-desc empty-desc"><span class="code">(I see no description here.)</span></div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Jeff%20Nyman/Contextual%20Descriptions.i7x"><span class='link'>Contextual Descriptions by Jeff Nyman</span></a>
+    &ensp;<span class="version">Version&nbsp;1/200930</span>
+      </div>
+  <div class="ext-desc">Provides a mechanism for contextually shifting descriptions.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Chris%20Conley/Conversation%20Builder.i7x"><span class='link'>Conversation Builder by Chris Conley</span></a>
+    &ensp;<span class="version">Version&nbsp;3/170420</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">An interactive question-and-answer system for building conversations.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Eric%20Eve/Conversation%20Framework.i7x"><span class='link'>Conversation Framework by Eric Eve</span></a>
+    &ensp;<span class="version">Version&nbsp;12</span>
+      </div>
+  <div class="ext-desc">A framework for conversations that allows saying hello and goodbye, abbreviated forms of ask and tell commands for conversing with the current interlocutor, and asking and telling about things as well as topics.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Conversation%20Framework%20IT.i7x"><span class='link'>Conversation Framework IT by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;11/140605</span>
+      </div>
+  <div class="ext-desc">Translation in italian of Version 11 of Conversation Framework by Eric Eve.
+
+A framework for conversations that allows saying hello and goodbye, abbreviated forms of ask and tell commands for conversing with the current interlocutor, and asking and telling about things as well as topics.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Eric%20Eve/Conversation%20Nodes.i7x"><span class='link'>Conversation Nodes by Eric Eve</span></a>
+    &ensp;<span class="version">Version&nbsp;7</span>
+      </div>
+  <div class="ext-desc">Builds on Conversational Defaults and adds the ability to define particular points in a conversational thread (nodes) at which particular conversational options become available.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Conversation%20Nodes%20IT.i7x"><span class='link'>Conversation Nodes IT by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;7</span>
+      </div>
+  <div class="ext-desc">Translation in italian of Version 7 of Conversation Nodes by Eric Eve.
+
+Builds on Conversational Defaults and adds the ability to define particular points in a conversational thread (nodes) at which particular conversational options become available.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Eric%20Eve/Conversation%20Package.i7x"><span class='link'>Conversation Package by Eric Eve</span></a>
+    &ensp;<span class="version">Version&nbsp;3</span>
+      </div>
+  <div class="ext-desc">This extension includes both Conversation Nodes and Conversation Suggestions, and makes the suggestions aware of conversation nodes. It therefore includes the complete conversational system in one package. It also requires Conversation Responses, Conversational Defaults, Conversation Framework and Epistemology. The documentation for this extension give some guidance on how these other extensions can be mixed and matched.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Conversation%20Package%20IT.i7x"><span class='link'>Conversation Package IT by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;3</span>
+      </div>
+  <div class="ext-desc">Translation in italian of Version 3 of Conversation Package by Eric Eve.
+
+This extension includes both Conversation Nodes and Conversation Suggestions, and makes the suggestions aware of conversation nodes. It therefore includes the complete conversational system in one package. It also requires Conversation Responses, Conversational Defaults, Conversation Framework and Epistemology. The documentation for this extension give some guidance on how these other extensions can be mixed and matched.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Eric%20Eve/Conversation%20Responses.i7x"><span class='link'>Conversation Responses by Eric Eve</span></a>
+    &ensp;<span class="version">Version&nbsp;7</span>
+      </div>
+  <div class="ext-desc">Provides a meaning for defining responses to conversational commands (such as ASK FRED ABOUT GARDEN) as a series of rules.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Conversation%20Responses%20IT.i7x"><span class='link'>Conversation Responses IT by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;7</span>
+      </div>
+  <div class="ext-desc">Translation in italian of Version 7 of Conversation Responses by Eric Eve.
+
+Provides a meaning for defining responses to conversational commands (such as ASK FRED ABOUT GARDEN) as a series of rules.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Eric%20Eve/Conversation%20Rules.i7x"><span class='link'>Conversation Rules by Eric Eve</span></a>
+    &ensp;<span class="version">Version&nbsp;7</span>
+      </div>
+  <div class="ext-desc">A way of controlling conversations using rules and tables. Also implements topic suggestions and Conversation nodes. Requires Plurality by Emily Short and Conversation Framework, Epistemology and List Control by Eric Eve.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Conversation%20Rules%20IT.i7x"><span class='link'>Conversation Rules IT by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;7/140608</span>
+      </div>
+  <div class="ext-desc">Translation in italian of Version 7 of Conversation Rules by Eric Eve.
+
+A way of controlling conversations using rules and tables. Also implements topic suggestions and Conversation nodes. Requires Plurality by Emily Short and Conversation Framework, Epistemology and List Control by Eric Eve.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Eric%20Eve/Conversation%20Suggestions.i7x"><span class='link'>Conversation Suggestions by Eric Eve</span></a>
+    &ensp;<span class="version">Version&nbsp;6/150607</span>
+      </div>
+  <div class="ext-desc">Provides a means of suggesting topics of conversation to the player, either in response to a TOPICS command or when NPCs are greeted. This extension requires Conversation Framework. Version 3 makes use of Complex Listing by Emily Short if it&#39;s included in the same game rather than indexed text to generate a list of suggestions.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Conversation%20Suggestions%20IT.i7x"><span class='link'>Conversation Suggestions IT by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;6</span>
+      </div>
+  <div class="ext-desc">Translation in italian of Version 6 of Conversation Suggestions by Eric Eve.
+
+Provides a means of suggesting topics of conversation to the player, either in response to a TOPICS command or when NPCs are greeted. This extension requires Conversation Framework. Version 3 makes use of Complex Listing by Emily Short if it&#39;s included in the same game rather than indexed text to generate a list of suggestions.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Daniel%20Stelzer/Conversation%20Touchability%20Fix.i7x"><span class='link'>Conversation Touchability Fix by Daniel Stelzer</span></a>
+      </div>
+  <div class="ext-desc">A simple change to the Standard Rules to allow conversation to work without a touchable noun.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Eric%20Eve/Conversational%20Defaults.i7x"><span class='link'>Conversational Defaults by Eric Eve</span></a>
+    &ensp;<span class="version">Version&nbsp;3</span>
+      </div>
+  <div class="ext-desc">Provides a set of rules to facilitate defining default conversational responses for different conversational commands targeted at various NPCs. This extension requires Conversation Framework.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Conversational%20Defaults%20IT.i7x"><span class='link'>Conversational Defaults IT by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;3</span>
+      </div>
+  <div class="ext-desc">Translation in italian of Version 3 of Conversational Defaults by Eric Eve.
+
+Provides a set of rules to facilitate defining default conversational responses for different conversational commands targeted at various NPCs. This extension requires Conversation Framework.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Creative%20Commons%20Public%20License%20IT.i7x"><span class='link'>Creative Commons Public License IT by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;2</span>
+      </div>
+  <div class="ext-desc">Un&#39;estensione in italiano per facilitare il rilascio di &#39;interactive fiction&#39; secondo la Creative Commons License v25. Basata sull&#39;estensione GNU General Public License v3 di Otis T. Dog.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Mike%20Ciul/Crowds.i7x"><span class='link'>Crowds by Mike Ciul</span></a>
+    &ensp;<span class="version">Version&nbsp;1/121214</span>
+      </div>
+  <div class="ext-desc">A way to implement collections of people that can spread across multiple rooms. The extension will keep track of the size of the crowd in each room. Requires Conditional Backdrops by Mike Ciul.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Juhana%20Leinonen/Debug%20Files.i7x"><span class='link'>Debug Files by Juhana Leinonen</span></a>
+    &ensp;<span class="version">Version&nbsp;2</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">A development tool for saving debugging information to an external text file during beta testing.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Michael%20Kielstra/Debug%20Tags.i7x"><span class='link'>Debug Tags by Michael Kielstra</span></a>
+    &ensp;<span class="version">Version&nbsp;1</span>
+      </div>
+  <div class="ext-desc">Take quick notes about what needs doing: bugs, ideas, et cetera.  Helpful for debugging.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Daniel%20Stelzer/Debugging.i7x"><span class='link'>Debugging by Daniel Stelzer</span></a>
+      </div>
+  <div class="ext-desc empty-desc"><span class="code">(I see no description here.)</span></div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Daniel%20Stelzer/Default%20Styles.i7x"><span class='link'>Default Styles by Daniel Stelzer</span></a>
+      </div>
+  <div class="ext-desc">Initializes and repurposes the unused Glulx text styles to provide more flexibility in formatting.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Emily%20Short/Deluxe%20Doors.i7x"><span class='link'>Deluxe Doors by Emily Short</span></a>
+    &ensp;<span class="version">Version&nbsp;4</span>
+      </div>
+  <div class="ext-desc">Allows for doors that are implemented as having independent &#39;faces&#39; -- to put a knocker on that can only be seen from on side, for instance, or to allow the player to lock one side with a key but the other with a latch. Also introduces a &#39;latched door&#39; kind.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Jeff%20Nyman/Description%20Decay.i7x"><span class='link'>Description Decay by Jeff Nyman</span></a>
+    &ensp;<span class="version">Version&nbsp;1/200930</span>
+      </div>
+  <div class="ext-desc">Provides a mechanism for allowing description levels to change based on number of visits</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Peter%20Orme/Developer%20Framework.i7x"><span class='link'>Developer Framework by Peter Orme</span></a>
+    &ensp;<span class="version">Version&nbsp;1/150130</span>
+      </div>
+  <div class="ext-desc">Common definitions useful for Inform7 authors and extension developers.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Xavid/Directional%20Disambiguation.i7x"><span class='link'>Directional Disambiguation by Xavid</span></a>
+    &ensp;<span class="version">Version&nbsp;1</span>
+      </div>
+  <div class="ext-desc">When a player types a standard direction in response to a disambiguation question, assume they meant to go that direction, not answer the question.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Jon%20Ingold/Disambiguation%20Control.i7x"><span class='link'>Disambiguation Control by Jon Ingold</span></a>
+    &ensp;<span class="version">Version&nbsp;10/170416</span>
+      </div>
+  <div class="ext-desc">Allows finer control over the disambiguation process used by Inform to decide what the player was referring to. Less guesswork, more questions asking for more input. Also removes the multiple-object-rejection in favour of asking for more information.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Mike%20Ciul/Disambiguation%20Override.i7x"><span class='link'>Disambiguation Override by Mike Ciul</span></a>
+    &ensp;<span class="version">Version&nbsp;1/121212</span>
+      </div>
+  <div class="ext-desc">Disables the disambiguation prompt on demand. Also provides a rulebook for disambiguating objects outside of an action context.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Andrew%20Plotkin/Disappearing%20Doors.i7x"><span class='link'>Disappearing Doors by Andrew Plotkin</span></a>
+    &ensp;<span class="version">Version&nbsp;1</span>
+      </div>
+  <div class="ext-desc">The ability to remove doors from the world and put them back.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Emily%20Short/Dishes.i7x"><span class='link'>Dishes by Emily Short</span></a>
+    &ensp;<span class="version">Version&nbsp;2</span>
+      </div>
+  <div class="ext-desc">Dishes is a convenience extension for use with Measured Liquid. It provides some standard-sized cups, glasses, graduated measuring cups, jugs, bottles, etc., as well as a corked bottle kind that opens with the use of a secondary cork object.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Dishes%20IT.i7x"><span class='link'>Dishes IT by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;2</span>
+      </div>
+  <div class="ext-desc">Translation in italian of Version 2 of Dishes by Emily Short.
+
+Dishes is a convenience extension for use with Measured Liquid. It provides some standard-sized cups, glasses, graduated measuring cups, jugs, bottles, etc., as well as a corked bottle kind that opens with the use of a secondary cork object.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Daniel%20Stelzer/Distant%20Movement.i7x"><span class='link'>Distant Movement by Daniel Stelzer</span></a>
+      </div>
+  <div class="ext-desc empty-desc"><span class="code">(I see no description here.)</span></div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Daniel%20Stelzer/Distant%20Room%20Descriptions.i7x"><span class='link'>Distant Room Descriptions by Daniel Stelzer</span></a>
+      </div>
+  <div class="ext-desc">This is a relatively simple extension which adds a new phrase: &quot;describe (place - an object) from the viewpoint of (item - a thing)&quot;. This should print the room description just as if the player had typed &quot;look&quot; while in the place. You can also leave off the viewpoint clause if it isn&#39;t necessary.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Jesse%20McGrew/Dynamic%20Objects.i7x"><span class='link'>Dynamic Objects by Jesse McGrew</span></a>
+    &ensp;<span class="version">Version&nbsp;8/140515</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Provides the ability to create new objects during game play.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Aaron%20Reed/Dynamic%20Rooms.i7x"><span class='link'>Dynamic Rooms by Aaron Reed</span></a>
+    &ensp;<span class="version">Version&nbsp;3</span>
+      </div>
+  <div class="ext-desc">Lets new rooms be created on the fly.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Jesse%20McGrew/Dynamic%20Tables.i7x"><span class='link'>Dynamic Tables by Jesse McGrew</span></a>
+    &ensp;<span class="version">Version&nbsp;5/140908</span>
+      </div>
+  <div class="ext-desc">Provides a way to change the capacity of a table during the game.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Hanon%20Ondricek/Easy%20Doors.i7x"><span class='link'>Easy Doors by Hanon Ondricek</span></a>
+    &ensp;<span class="version">Version&nbsp;3/160425</span>
+      </div>
+  <div class="ext-desc">Easy Doors provides a new kind of door which does not use map connections, and may be manipulated via rules more flexibly than the standard doors provided in Inform 7.  Version 3 removes elements for compatibility with 6M62</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Ron%20Newcomb/Editable%20Stored%20Actions.i7x"><span class='link'>Editable Stored Actions by Ron Newcomb</span></a>
+    &ensp;<span class="version">Version&nbsp;10</span>
+      </div>
+  <div class="ext-desc">This extension extends section 12.20 of Writing With Inform.  The individual parts of a stored action -- actor, noun, second noun, action name -- can be changed directly.  Also exposes new parts: request, text, participle, preposition, number, and each kind of value.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Mike%20Ciul/Effective%20Infinity.i7x"><span class='link'>Effective Infinity by Mike Ciul</span></a>
+    &ensp;<span class="version">Version&nbsp;1</span>
+      </div>
+  <div class="ext-desc">Provides a system of counting numbers which never go below 0 or above a specified maximum value. Any numbers above the maximum are considered infinite.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Daniel%20Stelzer/Empty%20Command%20Handling.i7x"><span class='link'>Empty Command Handling by Daniel Stelzer</span></a>
+      </div>
+  <div class="ext-desc">Adds a new hook into the parser, to edit a blank command before analyzing it.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Gavin%20Lambert/Enterable%20Underside.i7x"><span class='link'>Enterable Underside by Gavin Lambert</span></a>
+    &ensp;<span class="version">Version&nbsp;2/200926</span>
+      </div>
+  <div class="ext-desc">Adds the ability to enter &#39;under&#39; some object, such as hiding under a bed.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Exit%20Descriptions%20IT.i7x"><span class='link'>Exit Descriptions IT by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;2</span>
+      </div>
+  <div class="ext-desc">Basato sull&#39;espansione Version 2 of Exit Descriptions by Matthew Fletcher.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Eric%20Eve/Exit%20Lister.i7x"><span class='link'>Exit Lister by Eric Eve</span></a>
+    &ensp;<span class="version">Version&nbsp;11</span>
+      </div>
+  <div class="ext-desc">A status line exit-lister and an EXITS command, with optional colouring of unvisited exits. Selected rooms and doors can be optionally be excluded from the list of exits.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Gavin%20Lambert/Exit%20Lister.i7x"><span class='link'>Exit Lister by Gavin Lambert</span></a>
+    &ensp;<span class="version">Version&nbsp;4</span>
+      </div>
+  <div class="ext-desc">Automatic listing of available exits, with a reasonable dose of customisation built in.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Exit%20Lister.i7x"><span class='link'>Exit Lister by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;2/140823</span>
+      </div>
+  <div class="ext-desc">Based on Exit Lister by Eric Eve and Exit Descriptions by Matthew Fletcher. Appends a list of exit directions and names any previously visited rooms at the end of a room description and adds a list of available directions to the status line.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Exit%20Lister%20IT.i7x"><span class='link'>Exit Lister IT by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;2/140823</span>
+      </div>
+  <div class="ext-desc">Appends a list of exit directions and names any previously visited rooms at the end of a room description. Just italian responses here.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Xavid/Expanded%20Understanding.i7x"><span class='link'>Expanded Understanding by Xavid</span></a>
+    &ensp;<span class="version">Version&nbsp;4/200323</span>
+      </div>
+  <div class="ext-desc">Various tweaks to understand additional variations of commands and have cleverer, more specific error messages in common failure cases.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Gavin%20Lambert/Extended%20Banner.i7x"><span class='link'>Extended Banner by Gavin Lambert</span></a>
+    &ensp;<span class="version">Version&nbsp;5</span>
+      </div>
+  <div class="ext-desc">More control over what is printed in a banner, including an easily-included copyright line.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Erik%20Temple/Extended%20Debugging.i7x"><span class='link'>Extended Debugging by Erik Temple</span></a>
+    &ensp;<span class="version">Version&nbsp;2/100212</span>
+      </div>
+  <div class="ext-desc">Provides a way for the author to release a build of a game while retaining both custom and built-in debugging commands. Also wraps Inform&#39;s debug tracing routines in phrases that authors can use to trigger rule-tracing from the source text rather than from the command prompt and provides other debugging features.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Aaron%20Reed/Extended%20Grammar.i7x"><span class='link'>Extended Grammar by Aaron Reed</span></a>
+    &ensp;<span class="version">Version&nbsp;8/140501</span>
+      </div>
+  <div class="ext-desc">Adds some of the most commonly attempted verb synonyms and alternate grammar lines. Based on the Inform 6 extension ExpertGrammar.h by Emily Short.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Emily%20Short/Facing.i7x"><span class='link'>Facing by Emily Short</span></a>
+    &ensp;<span class="version">Version&nbsp;11/160611</span>
+      </div>
+  <div class="ext-desc">Provides actions to face a direction, look toward a named room, or look through a named door.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Facing%20IT.i7x"><span class='link'>Facing IT by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;10/140826</span>
+      </div>
+  <div class="ext-desc">Italian translation of Version 10 of Facing by Emily Short. Provides actions to face a direction, look toward a named room, or look through a named door.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Dannii%20Willis/Fancy%20Status%20Lines.i7x"><span class='link'>Fancy Status Lines by Dannii Willis</span></a>
+    &ensp;<span class="version">Version&nbsp;1/130201</span>
+      </div>
+  <div class="ext-desc empty-desc"><span class="code">(I see no description here.)</span></div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Jon%20Ingold/Far%20Away.i7x"><span class='link'>Far away by Jon Ingold</span></a>
+    &ensp;<span class="version">Version&nbsp;5/160517</span>
+      </div>
+  <div class="ext-desc">Creates an adjective for far-off items which cannot be touched.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Mike%20Ciul/Flexible%20Action%20Requirements.i7x"><span class='link'>Flexible Action Requirements by Mike Ciul</span></a>
+    &ensp;<span class="version">Version&nbsp;1</span>
+      </div>
+  <div class="ext-desc">Overrides carrying requirements for specific actions, and provides more nuanced carrying and touchability requirements when needed.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Peter%20Orme/Flexible%20Logger.i7x"><span class='link'>Flexible Logger by Peter Orme</span></a>
+    &ensp;<span class="version">Version&nbsp;3/201118</span>
+      </div>
+  <div class="ext-desc">A logging tool for I7 that lets you log to transcript and (with Glulx) to file</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Jon%20Ingold/Flexible%20Windows.i7x"><span class='link'>Flexible Windows by Jon Ingold</span></a>
+    &ensp;<span class="version">Version&nbsp;15/200828</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Exposes the Glk windows system so authors can completely control the creation and use of windows</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Stephen%20Granade/Footnotes.i7x"><span class='link'>Footnotes by Stephen Granade</span></a>
+    &ensp;<span class="version">Version&nbsp;2</span>
+      </div>
+  <div class="ext-desc">Provides a framework for organizing and displaying footnotes in a game. Version 2 makes Footnotes responsive and 6L38-compatible.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Andrew%20Schultz/Freezing%20Time%20on%20Rejects.i7x"><span class='link'>Freezing Time on Rejects by Andrew Schultz</span></a>
+    &ensp;<span class="version">Version&nbsp;1/120431</span>
+      </div>
+  <div class="ext-desc">An extension to make sure that rejected actions do not take a move. It is recommended that users modify this file if they do want an action to take a move.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Shin/Game%20Ending%20Reloaded.i7x"><span class='link'>Game Ending Reloaded by Shin</span></a>
+    &ensp;<span class="version">Version&nbsp;1</span>
+      </div>
+  <div class="ext-desc">Game Ending as defined in Version 2/090402 of the Standard Rules by Graham Nelson.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Nathanael%20Nerode/Gender%20Options.i7x"><span class='link'>Gender Options by Nathanael Nerode</span></a>
+    &ensp;<span class="version">Version&nbsp;3/170818</span>
+      </div>
+  <div class="ext-desc">More broad-minded English language gender/number model where male, female, and neuter are three separate true-false properties.  Allows for objects to respond to any specified combination of HE, SHE, IT, and THEY.  As fast as the Standard Rules.  Tested with Inform 6M62.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Nathanael%20Nerode/Gender%20Speedup.i7x"><span class='link'>Gender Speedup by Nathanael Nerode</span></a>
+    &ensp;<span class="version">Version&nbsp;1/170816</span>
+      </div>
+  <div class="ext-desc">When using Gender Options, clean up some I6 internals with functions related to gender which are irrelevant to English or rendered obsolete with Gender Options.  Since these are called in the depths of ListWriter this should slightly improve speed.  Not included in Gender Options due to likely interference with other extensions.  Requires Gender Options.  Probably will not work with non-English languages.  Tested with Inform 6M62.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Erik%20Temple/Glimmr%20Animation%20Fader%20-%20Black.i7x"><span class='link'>Glimmr Animation Fader - Black by Erik Temple</span></a>
+    &ensp;<span class="version">Version&nbsp;1/111030</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Provides a fader object for fading to or from 100% black. For use with Glimmr Canvas Animation.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Erik%20Temple/Glimmr%20Automap.i7x"><span class='link'>Glimmr Automap by Erik Temple</span></a>
+    &ensp;<span class="version">Version&nbsp;3/111022</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Provides a plug-and-play graphical automapping solution built on top of Mark Tilford&#39;s Automap extension. Can fall back to text-based map on interpreters that don&#39;t support graphics.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Erik%20Temple/Glimmr%20Automap%20Tileset.i7x"><span class='link'>Glimmr Automap Tileset by Erik Temple</span></a>
+    &ensp;<span class="version">Version&nbsp;1/111022</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">A tileset intended primarily for use with Glimmr Automap.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Erik%20Temple/Glimmr%20Bitmap%20Font.i7x"><span class='link'>Glimmr Bitmap Font by Erik Temple</span></a>
+    &ensp;<span class="version">Version&nbsp;2/101030</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">A bitmap font for use with the Glimmr system of extensions.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Erik%20Temple/Glimmr%20Canvas%20Animation.i7x"><span class='link'>Glimmr Canvas Animation by Erik Temple</span></a>
+    &ensp;<span class="version">Version&nbsp;2/160627</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Provides a &#39;track&#39;-based system for independent animation of graphic elements, canvases, and windows. Features animation presets, automated easing/tweening, and a detailed debugging log.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Erik%20Temple/Glimmr%20Canvas%20Editor.i7x"><span class='link'>Glimmr Canvas Editor by Erik Temple</span></a>
+    &ensp;<span class="version">Version&nbsp;2/110103</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">A GUI editor that allows you to visually generate compositions for use with projects based on Glimmr Canvas-Based Drawing. Outputs valid Glimmr/I7 source code.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Erik%20Temple/Glimmr%20Canvas-Based%20Drawing.i7x"><span class='link'>Glimmr Canvas-Based Drawing by Erik Temple</span></a>
+    &ensp;<span class="version">Version&nbsp;4/160626</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">A framework for drawing graphics of various types--from sprite images to painted text--to a Glulx graphics window. Takes an object-oriented approach, with graphic elements represented as individual objects.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Erik%20Temple/Glimmr%20Debugging%20Console.i7x"><span class='link'>Glimmr Debugging Console by Erik Temple</span></a>
+    &ensp;<span class="version">Version&nbsp;1/111022</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Provides a dynamic console window for Glimmr debugging output.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Erik%20Temple/Glimmr%20Drawing%20Commands.i7x"><span class='link'>Glimmr Drawing Commands by Erik Temple</span></a>
+    &ensp;<span class="version">Version&nbsp;3/160626</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Provides commands for displaying images, shape primitives (such as rectangles, boxes, and lines), user-specified bitmap drawings, image maps, and for text-painting using &#39;fonts&#39; with glyphs composed of either bitmaps or image files.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Erik%20Temple/Glimmr%20Form%20Fields.i7x"><span class='link'>Glimmr Form Fields by Erik Temple</span></a>
+    &ensp;<span class="version">Version&nbsp;1/110103</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Allows the author to define multiple fields for entering text in a graphics window. The basics of mouse and keyboard input are provided, including conversion of typed digits into numbers.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Erik%20Temple/Glimmr%20Graphic%20Hyperlinks.i7x"><span class='link'>Glimmr Graphic Hyperlinks by Erik Temple</span></a>
+    &ensp;<span class="version">Version&nbsp;2/160628</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Allows us to identify any number of rectangular areas of a Glulx graphic window as &#39;hotlinked&#39;. When the player clicks within one of these zones, a command will be entered on behalf of the player, or we can specify some appropriate response of our own.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Erik%20Temple/Glimmr%20Image%20Font.i7x"><span class='link'>Glimmr Image Font by Erik Temple</span></a>
+    &ensp;<span class="version">Version&nbsp;2/101030</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Provides a font made up of individual images for use with the Glimmr system of extensions.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Erik%20Temple/Glimmr%20Simple%20Graphics%20Window.i7x"><span class='link'>Glimmr Simple Graphics Window by Erik Temple</span></a>
+    &ensp;<span class="version">Version&nbsp;1/111022</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Creates a graphics window that can be used with any Flexible Windows project. If used with Glimmr Canvas-Based Drawing, also creates a canvas to be displayed in the window. Includes code for drawing a single image centered in the window.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Dannii%20Willis/Glk%20Events.i7x"><span class='link'>Glk Events by Dannii Willis</span></a>
+    &ensp;<span class="version">Version&nbsp;2/200807</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">A low level event handling system</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Gavin%20Lambert/Glk%20Input%20Suspending.i7x"><span class='link'>Glk Input Suspending by Gavin Lambert</span></a>
+    &ensp;<span class="version">Version&nbsp;1/200930</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Provides a mechanism to &#39;suspend&#39; line and character inputs in progress to allow something to be printed, and then input resumed afterwards.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Dannii%20Willis/Glk%20Object%20Recovery.i7x"><span class='link'>Glk Object Recovery by Dannii Willis</span></a>
+    &ensp;<span class="version">Version&nbsp;1/171025</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">A low level utility library for managing Glk references after restarting or restoring</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Dannii%20Willis/Glk%20Text%20Formatting.i7x"><span class='link'>Glk Text Formatting by Dannii Willis</span></a>
+    &ensp;<span class="version">Version&nbsp;1/180324</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Provides functions for controlling colours and reverse styling at character granularity</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Erik%20Temple/Glulx%20Debugging%20Console.i7x"><span class='link'>Glulx Debugging Console by Erik Temple</span></a>
+    &ensp;<span class="version">Version&nbsp;1/150110</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Provides a separate Glulx window for debugging messages. Compatible with Inform build 6L38. Requires v14 of Flexible Windows by Jon Ingold.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Dannii%20Willis/Glulx%20Definitions.i7x"><span class='link'>Glulx Definitions by Dannii Willis</span></a>
+    &ensp;<span class="version">Version&nbsp;1/160919</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Core definitions which other Glulx/Glk extensions depend on</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Emily%20Short/Glulx%20Entry%20Points.i7x"><span class='link'>Glulx Entry Points by Emily Short</span></a>
+    &ensp;<span class="version">Version&nbsp;10/200602</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Provides hooks to allow the author to write specialized multimedia behavior that would normally go through HandleGlkEvent. This is a rather dull utility library that will be of most use to authors wanting to write Glulx extensions compatible with other Glulx extensions already in use.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Erik%20Temple/Glulx%20Input%20Loops.i7x"><span class='link'>Glulx Input Loops by Erik Temple</span></a>
+    &ensp;<span class="version">Version&nbsp;3/120428</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Provides two types of input loop, primary and secondary, for more flexible use of multiple input sources. Also provides multiple entry points into and better tracking of input handling. Allows for easy handling of keystroke input.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Erik%20Temple/Glulx%20Real%20Time.i7x"><span class='link'>Glulx Real Time by Erik Temple</span></a>
+    &ensp;<span class="version">Version&nbsp;1/150115</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Allows the user to easily create multiple virtual timers for real-time events. Compatible with Inform build 6L38.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Erik%20Temple/Glulx%20Status%20Window%20Control.i7x"><span class='link'>Glulx Status Window Control by Erik Temple</span></a>
+    &ensp;<span class="version">Version&nbsp;2/101030</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Allows the author heightened control over the status line, including opening and closing it at will, using a background color rather than the default reversed-out display, specifying when the status line opens among multiple Glulx windows, or eliminating it altogether.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Emily%20Short/Glulx%20Text%20Effects.i7x"><span class='link'>Glulx Text Effects by Emily Short</span></a>
+    &ensp;<span class="version">Version&nbsp;5/150123</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Gives control over text formatting in Glulx.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Daniel%20Stelzer/Glulx%20Text%20Styles.i7x"><span class='link'>Glulx Text Styles by Daniel Stelzer</span></a>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Glulx Text Styles provides a more powerful way to set up special text effects for Glulx.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Jeff%20Sheets/Graphic%20Links.i7x"><span class='link'>Graphic Links by Jeff Sheets</span></a>
+    &ensp;<span class="version">Version&nbsp;3/161003</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Allows the author to set hyperlinks in the Simple Graphical Window and give instructions about what is to result from performing them.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Xavid/Graphical%20Map.i7x"><span class='link'>Graphical Map by Xavid</span></a>
+    &ensp;<span class="version">Version&nbsp;2/190831</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Provides support for an image-based map with a static background and icons for the player and optionally other things or doors.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Daniel%20Stelzer/Helpful%20Functions.i7x"><span class='link'>Helpful Functions by Daniel Stelzer</span></a>
+      </div>
+  <div class="ext-desc">A set of functions I have often found useful, with checks to prevent conflicts with extensions.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Eric%20Eve/Hiding%20Under.i7x"><span class='link'>Hiding Under by Eric Eve</span></a>
+    &ensp;<span class="version">Version&nbsp;4</span>
+      </div>
+  <div class="ext-desc">Allows things to be hidden under other things, using a many-to-one underconcealment relation. Can be used either standalone (with basic functionality) or in conjunction with Underside (to add fuller functionality to both extensions). Version 3 of Hiding Under avoids using phrases deprecated in Version 6E59 of Inform.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Hiding%20Under%20IT.i7x"><span class='link'>Hiding Under IT by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;4/140530</span>
+      </div>
+  <div class="ext-desc">Translation in italian of Version 4 of Hiding Under by Eric Eve.
+
+Allows things to be hidden under other things, using a many-to-one underconcealment relation. Can be used either standalone (with basic functionality) or in conjunction with Underside (to add fuller functionality to both extensions). Version 3 of Hiding Under avoids using phrases deprecated in Version 6E59 of Inform.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Dannii%20Willis/High%20Performance%20Indexed%20Text.i7x"><span class='link'>High Performance Indexed Text by Dannii Willis</span></a>
+    &ensp;<span class="version">Version&nbsp;1/121014</span>
+      </div>
+  <div class="ext-desc">This extension improves the performance of Indexed Text and Regular Expressions by altering much of their template code. There are no changes to how you use either feature.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Dannii%20Willis/Highscores.i7x"><span class='link'>Highscores by Dannii Willis</span></a>
+    &ensp;<span class="version">Version&nbsp;1/190811</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Record and review highscores to an external file</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Erik%20Temple/HTML%20Color%20Names%20for%20Glulx%20Text%20Effects.i7x"><span class='link'>HTML Color Names for Glulx Text Effects by Erik Temple</span></a>
+    &ensp;<span class="version">Version&nbsp;1/100619</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Provides a broad set of HTML color names for use with Glulx Text Effects, Simple Graphical Window, Flexible Windows, and/or other Glulx graphics/text extensions. Requires Glulx Text Effects by Emily Short.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Gavin%20Lambert/Hyperlink%20Extension%20Registry.i7x"><span class='link'>Hyperlink Extension Registry by Gavin Lambert</span></a>
+    &ensp;<span class="version">Version&nbsp;1/200930</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Provides a framework to allow multiple hyperlink-processing extensions to co-exist without stepping on each others&#39; toes.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Hyperlink%20Interface.i7x"><span class='link'>Hyperlink Interface by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;9/140814</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">This extension emulates Blue Lacuna&#39;s emphasized hyperlink system for simplifying common IF input (by Aaron Reed) substituting emphasis with hyperlinks. Nouns, directions, and topics can be clicked directly to examine, go, or discuss.
+
+Heavily based on Keyword Interface by Aaron Reed.
+
+Requires Basic Hyperlinks by Emily Short and Text Capture by Eric Eve.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Hyperlink%20Interface%20IT.i7x"><span class='link'>Hyperlink Interface IT by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;9/140604</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Translation in italian of Version 9/140604 of Hyperlink Interface (for Glulx only) by Leonardo Boselli.
+
+This extension emulates Blue Lacuna&#39;s emphasized hyperlink system for simplifying common IF input (by Aaron Reed) substituting emphasis with hyperlinks. Nouns, directions, and topics can be clicked directly to examine, go, or discuss.
+
+Heavily based on Keyword Interface by Aaron Reed.
+
+Requires Basic Hyperlinks by Emily Short and Text Capture by Eric Eve.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Dannii%20Willis/Hyperlinks.i7x"><span class='link'>Hyperlinks by Dannii Willis</span></a>
+      </div>
+  <div class="ext-desc empty-desc"><span class="code">(I see no description here.)</span></div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Gavin%20Lambert/Hyperlinks.i7x"><span class='link'>Hyperlinks by Gavin Lambert</span></a>
+    &ensp;<span class="version">Version&nbsp;1/200807</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Provides a core processing loop for hyperlinks.  This is a basic interface intended to be used by other extensions rather than directly in stories.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Jesse%20McGrew/Hypothetical%20Questions.i7x"><span class='link'>Hypothetical Questions by Jesse McGrew</span></a>
+    &ensp;<span class="version">Version&nbsp;4/180124</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Allows us to test the consequences of a phrase or action without permanently changing the game state.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Eric%20Eve/Implicit%20Actions.i7x"><span class='link'>Implicit Actions by Eric Eve</span></a>
+    &ensp;<span class="version">Version&nbsp;13</span>
+      </div>
+  <div class="ext-desc">Provides implicit taking, opening, closing, locking and unlocking actions for a variety of cases where this makes for smoother game play. The extension also defines phrases which make it easy to define additional implicit actions if desired. Version 11 can be used with Locksmith by Emily Short (although Implicit Actions covers most of what Locksmith does, and in most cases it will be better to use Implicit Actions without Locksmith). Requires  Version 5 (or above) of Text Capture by Eric Eve.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Implicit%20Actions%20IT.i7x"><span class='link'>Implicit Actions IT by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;11</span>
+      </div>
+  <div class="ext-desc">Provides implicit taking, opening, closing, locking and unlocking actions for a variety of cases where this makes for smoother game play. The extension also defines phrases which make it easy to define additional implicit actions if desired. Version 11 can be used with Locksmith by Emily Short (although Implicit Actions covers most of what Locksmith does, and in most cases it will be better to use Implicit Actions without Locksmith). Requires Plurality by Emily Short and Version 4 of Text Capture by Eric Eve.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Andrew%20Schultz/In-Line%20Topical%20Hints.i7x"><span class='link'>In-Line Topical Hints by Andrew Schultz</span></a>
+    &ensp;<span class="version">Version&nbsp;2/200530</span>
+      </div>
+  <div class="ext-desc">Lets the author offer the player in-line hints, with options for presentation. This extension requires Inform 6M62 or higher to run.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Matt%20Weiner/Indefinite%20Article%20Substitution%20Fix.i7x"><span class='link'>Indefinite Article Substitution Fix by Matt Weiner</span></a>
+    &ensp;<span class="version">Version&nbsp;1/161126</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Indefinite Article Substitution Fix (for Glulx only, at present) is intended to fix a bug in the interaction of indefinite articles with text substitutions. </div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Dannii%20Willis/Infra%20Undo.i7x"><span class='link'>Infra Undo by Dannii Willis</span></a>
+    &ensp;<span class="version">Version&nbsp;1/170502</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Handles undo using external files for very big story files</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Nathanael%20Nerode/Initial%20Cursor%20at%20Top%20or%20Bottom.i7x"><span class='link'>Initial Cursor at Top or Bottom by Nathanael Nerode</span></a>
+    &ensp;<span class="version">Version&nbsp;1/170827</span>
+      </div>
+  <div class="ext-desc">This small extension eliminates the three newlines printed before the banner.  It also provides a tool to attempt to place the cursor at the bottom of the screen, like old Infocom games.  Due to wild variance between interpreters, it is not reliable.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Daniel%20Stelzer/Inline%20Hyperlinks.i7x"><span class='link'>Inline Hyperlinks by Daniel Stelzer</span></a>
+    &ensp;<span class="version">Version&nbsp;3</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Provides a simple, HTML-inspired syntax for adding hyperlinks within say phrases. No manual management of hyperlinks required. Requires Text Capture by Eric Eve. Works seamlessly with, but does not require, Flexible Windows.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Erik%20Temple/Inline%20Hyperlinks.i7x"><span class='link'>Inline Hyperlinks by Erik Temple</span></a>
+    &ensp;<span class="version">Version&nbsp;3/161018</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Provides a simple, HTML-inspired syntax for adding hyperlinks within say phrases. No manual management of hyperlinks required. Requires Text Capture by Eric Eve. Works seamlessly with, but does not require, Flexible Windows.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Gavin%20Lambert/Inline%20Hyperlinks.i7x"><span class='link'>Inline Hyperlinks by Gavin Lambert</span></a>
+    &ensp;<span class="version">Version&nbsp;2/200930</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Provides a simple HTML-inspired syntax for adding hyperlinks within any say phrases.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Friends%20of%20I7/Interpreter%20Sniffing.i7x"><span class='link'>Interpreter Sniffing by Friends of I7</span></a>
+    &ensp;<span class="version">Version&nbsp;1/140209</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Phrases for testing, as far as is possible, which interpreter the story is running under.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Emily%20Short/Introductions.i7x"><span class='link'>Introductions by Emily Short</span></a>
+    &ensp;<span class="version">Version&nbsp;2</span>
+      </div>
+  <div class="ext-desc">Introductions provides an introductory paragraph about objects in a room description the first time the player looks in that location. It also allows the author to add segue text that will appear between one description and the next.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Italian.i7x"><span class='link'>Italian by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;1</span>
+      </div>
+  <div class="ext-desc">Parser e messaggi di base tradotti in italiano.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Massimo%20Stella/Italian%20Language.i7x"><span class='link'>Italian Language by Massimo Stella</span></a>
+    &ensp;<span class="version">Version&nbsp;3/171001</span>
+      </div>
+  <div class="ext-desc">To make Italian the language of play. Heavily based on code written by Massimo Stella. Now maintained by Leonardo Boselli. Requires &#39;Text Capture&#39; by Eric Eve.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Aaron%20Reed/Keyword%20Interface.i7x"><span class='link'>Keyword Interface by Aaron Reed</span></a>
+    &ensp;<span class="version">Version&nbsp;9/150607</span>
+      </div>
+  <div class="ext-desc">This extension emulates Blue Lacuna&#39;s emphasized keyword system for simplifying common IF input. Nouns, directions, and topics can be typed without a verb to examine, go, or discuss. Works with Glulx or z-code.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Keyword%20Interface%20IT.i7x"><span class='link'>Keyword Interface IT by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;9/140531</span>
+      </div>
+  <div class="ext-desc">Translation in italian of Version 9/140501 of Keyword Interface by Aaron Reed.
+
+This extension emulates Blue Lacuna&#39;s emphasized keyword system for simplifying common IF input. Nouns, directions, and topics can be typed without a verb to examine, go, or discuss. Works with Glulx or z-code.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Nathanael%20Nerode/Large%20Game%20Speedup.i7x"><span class='link'>Large Game Speedup by Nathanael Nerode</span></a>
+    &ensp;<span class="version">Version&nbsp;5/171007</span>
+      </div>
+  <div class="ext-desc">Performance improvements for games with large numbers of objects, by avoiding looping over all objects.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Eric%20Eve/Limited%20Implicit%20Actions.i7x"><span class='link'>Limited Implicit Actions by Eric Eve</span></a>
+    &ensp;<span class="version">Version&nbsp;3</span>
+      </div>
+  <div class="ext-desc">A cut-down version of Implicit Actions for use where code size may be restricted and the full functionality of Implicit Actions is not needed. Requires Plurality by Emily Short and is compatible with Locksmith by Emily Short.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Xavid/Liquids.i7x"><span class='link'>Liquids by Xavid</span></a>
+    &ensp;<span class="version">Version&nbsp;2/191114</span>
+      </div>
+  <div class="ext-desc">Basic support for sources of liquids and things that can hold a liquid, more minimalist than Liquid Handling by Al Golden.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Eric%20Eve/List%20Control.i7x"><span class='link'>List Control by Eric Eve</span></a>
+    &ensp;<span class="version">Version&nbsp;4</span>
+      </div>
+  <div class="ext-desc">Provides a means of using tables as shuffled, cyclic or stop lists.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Eric%20Eve/List%20Controller.i7x"><span class='link'>List Controller by Eric Eve</span></a>
+    &ensp;<span class="version">Version&nbsp;4</span>
+      </div>
+  <div class="ext-desc">Provides a means of using tables as shuffled, cyclic or stoping lists. This is an alternative to List Control that uses list controller objects instead of a Table of Table Types.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Emily%20Short/Location%20Images.i7x"><span class='link'>Location Images by Emily Short</span></a>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Allows the author to set per-room images and show these as the player moves from room to room. Requires Simple Graphical Window by Emily Short.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Locksmith%20IT.i7x"><span class='link'>Locksmith IT by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;7</span>
+      </div>
+  <div class="ext-desc">Gestione implicita di porte e contenitori cosicché la manipolazione della chiusura sia automatica se il giocatore possiede le chiavi necessarie. Basato su Version 7 of Locksmith by Emily Short.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Mike%20Ciul/Lost%20Items.i7x"><span class='link'>Lost Items by Mike Ciul</span></a>
+    &ensp;<span class="version">Version&nbsp;3/121206</span>
+      </div>
+  <div class="ext-desc">Prints a special message instead of &#39;You can&#39;t see any such thing&#39; when certain items are out of scope, indicating that they have disappeared unexpectedly. Useful for flashbacks, theft, and NPCs who might sneak away.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Map.i7x"><span class='link'>Map by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;1/140824</span>
+      </div>
+  <div class="ext-desc">Automatic walk in a map.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Map%20IT.i7x"><span class='link'>Map IT by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;1/140824</span>
+      </div>
+  <div class="ext-desc">Automatic walk in a map. Translated in Italian.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Emily%20Short/Measured%20Liquid.i7x"><span class='link'>Measured Liquid by Emily Short</span></a>
+    &ensp;<span class="version">Version&nbsp;6/201125</span>
+      </div>
+  <div class="ext-desc">Measured Liquid provides a concept of volume, together with the ability to fill containers, pour measured amounts of liquid, and drink from containers. It handles mixtures as well, if desired. It is compatible with, but does not require, the Metric Units extension by Graham Nelson.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Measured%20Liquid%20IT.i7x"><span class='link'>Measured Liquid IT by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;6/140613</span>
+      </div>
+  <div class="ext-desc">Translation in italian of Version 6 of Measured Liquid by Emily Short.
+
+Measured Liquid provides a concept of volume, together with the ability to fill containers, pour measured amounts of liquid, and drink from containers. It handles mixtures as well, if desired. It is compatible with, but does not require, the Metric Units extension by Graham Nelson.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Dannii%20Willis/Menus.i7x"><span class='link'>Menus by Dannii Willis</span></a>
+    &ensp;<span class="version">Version&nbsp;1/160728</span>
+      </div>
+  <div class="ext-desc">Display full-screen menus defined by tables</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Wade%20Clarke/Menus.i7x"><span class='link'>Menus by Wade Clarke</span></a>
+    &ensp;<span class="version">Version&nbsp;5</span>
+      </div>
+  <div class="ext-desc">Lets you include a menu system of help, hints and/or other information in your Glulx or Z-Code project for Inform 6M62 or later. This upgrade of Emily Short&#39;s classic Menus extension features user-friendly single keypress controls, a more sophisticated UI, compatibility with screen readers and portable devices, an optional book mode with automatic pagination, and isolated message content to make translations easier. Classic Menus tables can be reformatted for this extension with a little work.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Menus%20IT.i7x"><span class='link'>Menus IT by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;3</span>
+      </div>
+  <div class="ext-desc">A table-based way to display full-screen menus to the player. Semplicemente tradotto in italiano.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/MilleUna%20Conversation.i7x"><span class='link'>MilleUna Conversation by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;1/140824</span>
+      </div>
+  <div class="ext-desc">The part of the MilleUna Framework that manages conversations.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/MilleUna%20Conversation%20IT.i7x"><span class='link'>MilleUna Conversation IT by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;1/140824</span>
+      </div>
+  <div class="ext-desc">The part of the MilleUna Framework that manages conversations. Translated in Italian.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/MilleUna%20for%20Gargoyle.i7x"><span class='link'>MilleUna for Gargoyle by Leonardo Boselli</span></a>
+      </div>
+  <div class="ext-desc">No documentation yet.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/MilleUna%20for%20Gargoyle%20with%20graphics.i7x"><span class='link'>MilleUna for Gargoyle with graphics by Leonardo Boselli</span></a>
+      </div>
+  <div class="ext-desc">No documentation yet.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/MilleUna%20for%20Quixe.i7x"><span class='link'>MilleUna for Quixe by Leonardo Boselli</span></a>
+      </div>
+  <div class="ext-desc">Release for web with the Quixe interpreter.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/MilleUna%20for%20Quixe%20with%20graphics.i7x"><span class='link'>MilleUna for Quixe with graphics by Leonardo Boselli</span></a>
+      </div>
+  <div class="ext-desc">Release for web with the Quixe interpreter.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/MilleUna%20Framework.i7x"><span class='link'>MilleUna Framework by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;1/140826</span>
+      </div>
+  <div class="ext-desc">An all-in-one framework to write online interactive fiction with hyperlinks and other useful stuff.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/MilleUna%20Framework%20IT.i7x"><span class='link'>MilleUna Framework IT by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;1/140824</span>
+      </div>
+  <div class="ext-desc">An all-in-one framework to write online interactive fiction with hyperlinks and other useful stuff. Translated in Italian.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/MilleUna%20Help.i7x"><span class='link'>MilleUna Help by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;1/140824</span>
+      </div>
+  <div class="ext-desc">The part of the MilleUna Framework that manages help, tutorials and so on.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/MilleUna%20Help%20IT.i7x"><span class='link'>MilleUna Help IT by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;1/140824</span>
+      </div>
+  <div class="ext-desc">The part of the MilleUna Framework that manages help, tutorials and so on. Translated in Italian.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/MilleUna%20Interface.i7x"><span class='link'>MilleUna Interface by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;1/140824</span>
+      </div>
+  <div class="ext-desc">The part of the MilleUna Framework that manages the user friendly interface.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/MilleUna%20Interface%20IT.i7x"><span class='link'>MilleUna Interface IT by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;1/140824</span>
+      </div>
+  <div class="ext-desc">The part of the MilleUna Framework that manages the user friendly interface. Translated in Italian.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/MilleUna%20World.i7x"><span class='link'>MilleUna World by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;1/140826</span>
+      </div>
+  <div class="ext-desc">The part of the MilleUna Framework that manages additional features of the world model.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/MilleUna%20World%20IT.i7x"><span class='link'>MilleUna World IT by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;1/140826</span>
+      </div>
+  <div class="ext-desc">The part of the MilleUna Framework that manages additional features of the world model.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/David%20Corbett/Mobile%20Doors.i7x"><span class='link'>Mobile Doors by David Corbett</span></a>
+    &ensp;<span class="version">Version&nbsp;1</span>
+      </div>
+  <div class="ext-desc">Inform 7 allows the connections between rooms to be modified during play, but doors never change. This extension makes doors as versatile as rooms.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Emily%20Short/Modern%20Conveniences.i7x"><span class='link'>Modern Conveniences by Emily Short</span></a>
+    &ensp;<span class="version">Version&nbsp;5</span>
+      </div>
+  <div class="ext-desc">Modern Conveniences creates kitchen and bathroom kinds of room, which will automatically be furnished with a set of plausible appliances. (This was originally an example in the manual of how to create extensions, and an annotated version may still be found there.) Version 3 adds compatibility with Measured Liquid, modeling flowing water from taps.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Emily%20Short/Modified%20Exit.i7x"><span class='link'>Modified Exit by Emily Short</span></a>
+    &ensp;<span class="version">Version&nbsp;6</span>
+      </div>
+  <div class="ext-desc">Changes the handling of the EXIT action, allowing commands such as EXIT PLATFORM and GET OUT OF CHAIR, making characters leave enterable objects before traveling, and altering the default interpretation of &gt;OUT when the player is neither inside an object nor in a room with an outside exit. Updated for adaptive text.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Daniel%20Stelzer/Modified%20Timekeeping.i7x"><span class='link'>Modified Timekeeping by Daniel Stelzer</span></a>
+      </div>
+  <div class="ext-desc">Changes the one-minute-per-turn rule to account for failed and implicit actions.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Emily%20Short/Mood%20Variations.i7x"><span class='link'>Mood Variations by Emily Short</span></a>
+    &ensp;<span class="version">Version&nbsp;3</span>
+      </div>
+  <div class="ext-desc">Allows the author to define a mood value for characters and then use text substitutions such as &#39;[when bored]The king fidgets on his throne[or sleepy]The king snores[at other times]The king grins[end when].&#39; Moods will be interpreted in &#39;writing a paragraph&#39; and similar contexts as the mood of the person described in the paragraph, but at other times according to the mood of the person to whom the player is currently speaking.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Daniel%20Stelzer/Multiple%20Actors.i7x"><span class='link'>Multiple Actors by Daniel Stelzer</span></a>
+    &ensp;<span class="version">Version&nbsp;2/150226</span>
+      </div>
+  <div class="ext-desc">Allows the player to give commands to multiple actors at the same time. (This version heavily modifies the I6 parser.)</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Massimo%20Stella/Multiple%20Sounds.i7x"><span class='link'>Multiple Sounds by Massimo Stella</span></a>
+    &ensp;<span class="version">Version&nbsp;3</span>
+      </div>
+  <div class="ext-desc">Provides facilities for the basic reproduction of multiple-channel audio with loops under Glulx.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Mike%20Ciul/Multitudes.i7x"><span class='link'>Multitudes by Mike Ciul</span></a>
+    &ensp;<span class="version">Version&nbsp;1/110513</span>
+      </div>
+  <div class="ext-desc">A way to implement collections of objects that can spread across multiple rooms, like stones in a pile of gravel. The player may interact with individual objects from the collection, and the extension will keep track of how many are in each room. Requires Conditional Backdrops by Mike Ciul.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Daniel%20Stelzer/Music.i7x"><span class='link'>Music by Daniel Stelzer</span></a>
+      </div>
+  <div class="ext-desc">A music-focused sound extension, which allows authors to loop sounds on different channels and fade between them.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Dannii%20Willis/Mutable%20Kinds.i7x"><span class='link'>Mutable Kinds by Dannii Willis</span></a>
+    &ensp;<span class="version">Version&nbsp;1/121012</span>
+      </div>
+  <div class="ext-desc">Change the default values of the properties of Mutable Kinds at run-time</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Nathanael%20Nerode/Nathanael&#39;s%20Cookbook.i7x"><span class='link'>Nathanael&#39;s Cookbook by Nathanael Nerode</span></a>
+    &ensp;<span class="version">Version&nbsp;2/171001</span>
+      </div>
+  <div class="ext-desc">This is just a collection of worked examples illustrating various features of Inform.  There isn&#39;t actually anything in the extension per se, but the examples in the documentation can be click-pasted in the Inform IDE for convenience.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Nathanael%20Nerode/Neutral%20Standard%20Responses.i7x"><span class='link'>Neutral Standard Responses by Nathanael Nerode</span></a>
+    &ensp;<span class="version">Version&nbsp;4/171007</span>
+      </div>
+  <div class="ext-desc">Replaces misleading, vague, and narratively-voiced parser messages with instructive, clarifying, and neutral versions, respectively.  For Inform 6M62.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Jim%20Aikin/Notepad.i7x"><span class='link'>Notepad by Jim Aikin</span></a>
+    &ensp;<span class="version">Version&nbsp;3</span>
+      </div>
+  <div class="ext-desc">A system for creating an in-game notepad that the player can write on.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Notepad%20IT.i7x"><span class='link'>Notepad IT by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;2</span>
+      </div>
+  <div class="ext-desc">A system for creating an in-game notepad that the player can write on. Unico cambiamento: traduzione in italiano.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Eric%20Eve/NPC%20Implicit%20Actions.i7x"><span class='link'>NPC Implicit Actions by Eric Eve</span></a>
+    &ensp;<span class="version">Version&nbsp;4</span>
+      </div>
+  <div class="ext-desc">A basic extension of the Implicit Actions extension into actions carried out by NPCs. This extension automatically includes Implicit Actions.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/NPC%20Implicit%20Actions%20IT.i7x"><span class='link'>NPC Implicit Actions IT by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;2</span>
+      </div>
+  <div class="ext-desc">A basic extension of the Implicit Actions extension into actions carried out by NPCs. This extension automatically includes Implicit Actions. Solo tradotto in italiano.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Jeff%20Nyman/Nuanced%20Timekeeping.i7x"><span class='link'>Nuanced Timekeeping by Jeff Nyman</span></a>
+    &ensp;<span class="version">Version&nbsp;1/201001</span>
+      </div>
+  <div class="ext-desc">Provides more nuanced aspects of tracking time within a game.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Aaron%20Reed/Numbered%20Disambiguation%20Choices.i7x"><span class='link'>Numbered Disambiguation Choices by Aaron Reed</span></a>
+    &ensp;<span class="version">Version&nbsp;10/190320</span>
+      </div>
+  <div class="ext-desc">Numbers the options in disambiguation questions, to help new players and solve the &#39;disambiguation loop&#39; problem caused by indistinguishable objects.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Numbered%20Disambiguation%20Choices.i7x"><span class='link'>Numbered Disambiguation Choices by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;7/140902</span>
+      </div>
+  <div class="ext-desc">Numbers the options in disambiguation questions, to help new players and solve the &#39;disambiguation loop&#39; problem caused by indistinguishable objects. Modified to support hyperlinks.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Numbered%20Disambiguation%20Choices%20IT.i7x"><span class='link'>Numbered Disambiguation Choices IT by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;2</span>
+      </div>
+  <div class="ext-desc">Numbers the options in disambiguation questions, to help new players and solve the &#39;disambiguation loop&#39; problem caused by indistinguishable objects. Semplicemente tradotto in italiano.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Peter%20Orme/Object%20Descriptors.i7x"><span class='link'>Object Descriptors by Peter Orme</span></a>
+    &ensp;<span class="version">Version&nbsp;3</span>
+      </div>
+  <div class="ext-desc empty-desc"><span class="code">(I see no description here.)</span></div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Brady%20Garvin/Object%20Kinds.i7x"><span class='link'>Object Kinds by Brady Garvin</span></a>
+    &ensp;<span class="version">Version&nbsp;2</span>
+      </div>
+  <div class="ext-desc">The ability to treat object kinds as values.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Xavid/Object%20Matching.i7x"><span class='link'>Object Matching by Xavid</span></a>
+    &ensp;<span class="version">Version&nbsp;2</span>
+      </div>
+  <div class="ext-desc">Support for getting the matched object when matching a snippet against a pattern and for disabling clarification when a command or snippet is ambiguous.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Juhana%20Leinonen/Object%20Response%20Tests.i7x"><span class='link'>Object Response Tests by Juhana Leinonen</span></a>
+    &ensp;<span class="version">Version&nbsp;7</span>
+      </div>
+  <div class="ext-desc">A development tool for testing all actions on any given object - or one action on all objects - at once to see whether the game&#39;s responses are sensible.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Mike%20Ciul/Objects%20Matching%20Snippets.i7x"><span class='link'>Objects Matching Snippets by Mike Ciul</span></a>
+      </div>
+  <div class="ext-desc">Objects Matching Snippets is a very simple extension that provides a convenient way to search for names of objects within a snippet such as the player&#39;s command or the topic understood.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Emily%20Short/Ordinary%20Room%20Description.i7x"><span class='link'>Ordinary Room Description by Emily Short</span></a>
+    &ensp;<span class="version">Version&nbsp;3</span>
+      </div>
+  <div class="ext-desc">An extension to go with Room Description Control, which emulates as closely as possible the behavior of Inform defaults, but allows the intervention of Room Description Control.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Daniel%20Stelzer/Output%20Silencing.i7x"><span class='link'>Output Silencing by Daniel Stelzer</span></a>
+      </div>
+  <div class="ext-desc empty-desc"><span class="code">(I see no description here.)</span></div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Nathanael%20Nerode/Parser%20Error%20Number%20Bugfix.i7x"><span class='link'>Parser Error Number Bugfix by Nathanael Nerode</span></a>
+    &ensp;<span class="version">Version&nbsp;1</span>
+      </div>
+  <div class="ext-desc">Fixes a nasty bug in the I7 error names in Inform 7 version 6M62 (and probably earlier).</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Patrollers%20IT.i7x"><span class='link'>Patrollers IT by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;11</span>
+      </div>
+  <div class="ext-desc">Based on Version 11 of Patrollers by Michael Callaghan.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Ron%20Newcomb/Permission%20to%20Visit.i7x"><span class='link'>Permission to Visit by Ron Newcomb</span></a>
+    &ensp;<span class="version">Version&nbsp;7</span>
+      </div>
+  <div class="ext-desc">In lieu of compass directions, we may VISIT, ATTEND, GO TO, and FIND various people, events, places, and things.  Characters may INVITE, PERMIT, and FORBID each other to or from their respective domains.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Ron%20Newcomb/Phrases%20for%20Adaptive%20Pacing.i7x"><span class='link'>Phrases for Adaptive Pacing by Ron Newcomb</span></a>
+      </div>
+  <div class="ext-desc">We may ask the time when (a description of scenes) began/ended; the number of turns since (a description of scenes) began/ended; if (a future event) is soon; the time/turns until (a future event); the time/turns when (a future event). We may also un-schedule a future event with &#39;never shall&#39;; begin or end a scene on an event; say a time &#39;as a time period&#39;; repeat through future events; and change the turns-to-minutes ratio with &#39;per&#39;.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Ron%20Newcomb/Phrases%20for%20Tables%20with%20Topics.i7x"><span class='link'>Phrases for Tables with Topics by Ron Newcomb</span></a>
+    &ensp;<span class="version">Version&nbsp;3</span>
+      </div>
+  <div class="ext-desc">This grants five new phrases regarding the player&#39;s command, the matched text, and the topic understood: if one is a topic listed in a table, if one includes or matches a topic listed in a table, what corresponds to one within a table, and the last phrase corrects a bug so the topic understood may be used within an understand-as-mistake line.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Nate%20Cull/Planner.i7x"><span class='link'>Planner by Nate Cull</span></a>
+    &ensp;<span class="version">Version&nbsp;2/140513</span>
+      </div>
+  <div class="ext-desc">A universal goal planner for self-directed NPCs.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Daniel%20Stelzer/Play%20Counter.i7x"><span class='link'>Play Counter by Daniel Stelzer</span></a>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Allows an author to check how many times their story has been played.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Sean%20Turner/Plugs%20and%20Sockets.i7x"><span class='link'>Plugs and Sockets by Sean Turner</span></a>
+    &ensp;<span class="version">Version&nbsp;4/170924</span>
+      </div>
+  <div class="ext-desc">System for handling plugs and sockets.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Shin/Points%20Awarding%20Reloaded.i7x"><span class='link'>Points Awarding Reloaded by Shin</span></a>
+    &ensp;<span class="version">Version&nbsp;1</span>
+      </div>
+  <div class="ext-desc">Points Awarding as defined in Version 2/090402 of the Standard Rules by Graham Nelson.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Aaron%20Reed/Poor%20Man&#39;s%20Mistype.i7x"><span class='link'>Poor Man&#39;s Mistype by Aaron Reed</span></a>
+    &ensp;<span class="version">Version&nbsp;8</span>
+      </div>
+  <div class="ext-desc">Adds basic typo correction by checking the first few letters of misunderstood input against the printed names of nearby objects. Requires version 15 of Smarter Parser by Aaron Reed. Supports Scope Caching by Mike Ciul for faster performance.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Peter%20Orme/Possible%20Movements.i7x"><span class='link'>Possible Movements by Peter Orme</span></a>
+    &ensp;<span class="version">Version&nbsp;2/130115</span>
+      </div>
+  <div class="ext-desc">This provides two commands available to the player: &quot;exits&quot; which lists all the obvious exits in the current location, and &quot;enterables&quot; which lists the enterable things. </div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Emily%20Short/Postures.i7x"><span class='link'>Postures by Emily Short</span></a>
+    &ensp;<span class="version">Version&nbsp;2/180528</span>
+      </div>
+  <div class="ext-desc">Postures defines three postures -- seated, standing, and reclining -- and allows pieces of furniture to specify which postures are possible and preferred when the player is on those furnishings.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Emily%20Short/Power%20Sources.i7x"><span class='link'>Power Sources by Emily Short</span></a>
+    &ensp;<span class="version">Version&nbsp;2</span>
+      </div>
+  <div class="ext-desc">Power Sources provides an implementation of plugs and batteries, and is designed to be used alongside Computers or as a base for other device implementations. It requires Plugs and Sockets by Sean Turner.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Gavin%20Lambert/Prepositional%20Correctness.i7x"><span class='link'>Prepositional Correctness by Gavin Lambert</span></a>
+    &ensp;<span class="version">Version&nbsp;2/200926</span>
+      </div>
+  <div class="ext-desc">Provides a way to customise the prepositions used to refer to containment or support, and perhaps other custom relationships added by other extensions.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Taryn%20Michelle/Print%20Stage%20Detection.i7x"><span class='link'>Print Stage Detection by Taryn Michelle</span></a>
+    &ensp;<span class="version">Version&nbsp;1</span>
+      </div>
+  <div class="ext-desc">&#39;Printing the name&#39; rules make TWO passes over the same object when Inform needs to determine the appropriate article to print. This is a non-issue for many rules, but &#39;printing the name&#39; rules with side effects may need to know which stage is currently being processed (article-choosing or name-printing), so that they can avoid double-execution of any side effects.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Daniel%20Stelzer/Problem-Solving%20Characters.i7x"><span class='link'>Problem-Solving Characters by Daniel Stelzer</span></a>
+    &ensp;<span class="version">Version&nbsp;2</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">This extension enables the characters to sensibly circumvent obstacles to their desired actions.  Intended for works in which the non-player characters perform game actions just like the player-character, but cannot be strictly scripted because of a changing gameworld.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Ron%20Newcomb/Problem-Solving%20Characters.i7x"><span class='link'>Problem-Solving Characters by Ron Newcomb</span></a>
+    &ensp;<span class="version">Version&nbsp;2</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">This extension enables the characters to sensibly circumvent obstacles to their desired actions.  Intended for works in which the non-player characters perform game actions just like the player-character, but cannot be strictly scripted because of a changing gameworld.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Emily%20Short/Property%20Checking.i7x"><span class='link'>Property Checking by Emily Short</span></a>
+    &ensp;<span class="version">Version&nbsp;4</span>
+      </div>
+  <div class="ext-desc">A light testing extension to identify rooms and game items that may still be lacking descriptions or other properties.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Michael%20Callaghan/Questions.i7x"><span class='link'>Questions by Michael Callaghan</span></a>
+    &ensp;<span class="version">Version&nbsp;5/150418</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">An extension to allow us to suspend normal parser input to receive and respond to answers to questions.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Michael%20Martin/Quip-Based%20Conversation.i7x"><span class='link'>Quip-Based Conversation by Michael Martin</span></a>
+    &ensp;<span class="version">Version&nbsp;5/171116</span>
+      </div>
+  <div class="ext-desc">An extension to Reactable Quips to allow for more traditional menu-based conversation.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Quip-Based%20Conversation%20IT.i7x"><span class='link'>Quip-Based Conversation IT by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;4</span>
+      </div>
+  <div class="ext-desc">Un[&#39;]estensione a Reactable Quips per permettere un più tradizionale consersazione basata su menù. L[&#39;]unica modifica è la traduzione in italiano.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Mikael%20Segercrantz/Randomness.i7x"><span class='link'>Randomness by Mikael Segercrantz</span></a>
+    &ensp;<span class="version">Version&nbsp;2/170921</span>
+      </div>
+  <div class="ext-desc">Random number generation using a simple seedable pseudorandom number generator.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/B%20David%20Paulsen/Rapid%20Prototyping.i7x"><span class='link'>Rapid Prototyping by B David Paulsen</span></a>
+    &ensp;<span class="version">Version&nbsp;1</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">A way to create and extend a game world on the fly during testing via a REPL idiom.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Michael%20Martin/Reactable%20Quips.i7x"><span class='link'>Reactable Quips by Michael Martin</span></a>
+    &ensp;<span class="version">Version&nbsp;10/171116</span>
+      </div>
+  <div class="ext-desc">A table-based approach to NPC conversation chains, as well as allowing rules to fire on lines of conversation.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Reactable%20Quips%20IT.i7x"><span class='link'>Reactable Quips IT by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;9</span>
+      </div>
+  <div class="ext-desc">Un approccio basato su tabolo per le conversazioni con gli NPC. L&#39;unica modifica è la traduzione in italiano.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Ron%20Newcomb/Real%20Date%20and%20Time.i7x"><span class='link'>Real Date and Time by Ron Newcomb</span></a>
+    &ensp;<span class="version">Version&nbsp;2</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Allows the author to get the real-world time and date from the player&#39;s computer.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Erik%20Temple/Real-Time%20Delays.i7x"><span class='link'>Real-Time Delays by Erik Temple</span></a>
+    &ensp;<span class="version">Version&nbsp;1/100607</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Allows the author to specify a delay of a given number of seconds/milliseconds before continuing the action.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Emily%20Short/Recorded%20Endings.i7x"><span class='link'>Recorded Endings by Emily Short</span></a>
+    &ensp;<span class="version">Version&nbsp;5</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Records the endings the player encounters in multiple play-throughs to an external file; then adds an ENDINGS option to the final question to allow the player to review which endings he has seen so far.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Juhana%20Leinonen/Regional%20Travel.i7x"><span class='link'>Regional Travel by Juhana Leinonen</span></a>
+    &ensp;<span class="version">Version&nbsp;2</span>
+      </div>
+  <div class="ext-desc">Allows the player to travel between regions. Useful for example when the player travels between large regions far apart from each other (e.g. cities), or for traveling in vehicles and public transportation.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Jeff%20Nyman/Relative%20Placement%20and%20Direction.i7x"><span class='link'>Relative Placement and Direction by Jeff Nyman</span></a>
+    &ensp;<span class="version">Version&nbsp;1/201001</span>
+      </div>
+  <div class="ext-desc">allowing relative directional movement as well as locationally relative descriptions.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Release%20for%20Gargoyle.i7x"><span class='link'>Release for Gargoyle by Leonardo Boselli</span></a>
+      </div>
+  <div class="ext-desc empty-desc"><span class="code">(I see no description here.)</span></div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Release%20for%20Quixe.i7x"><span class='link'>Release for Quixe by Leonardo Boselli</span></a>
+      </div>
+  <div class="ext-desc empty-desc"><span class="code">(I see no description here.)</span></div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Aaron%20Reed/Remembering.i7x"><span class='link'>Remembering by Aaron Reed</span></a>
+    &ensp;<span class="version">Version&nbsp;9/140430</span>
+      </div>
+  <div class="ext-desc">Replaces &#39;You can&#39;t see any such thing&#39; for a seen but out-of-scope noun with a message acknowledging that the parser recognizes the object. With Glulx, also keeps track of where the player last saw that object.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Daniel%20Stelzer/Remembering.i7x"><span class='link'>Remembering by Daniel Stelzer</span></a>
+    &ensp;<span class="version">Version&nbsp;9/140430</span>
+      </div>
+  <div class="ext-desc">Replaces &#39;You can&#39;t see any such thing&#39; for a seen but out-of-scope noun with a message acknowledging that the parser recognizes the object. With Glulx, also keeps track of where the player last saw that object.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Remembering.i7x"><span class='link'>Remembering by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;9/140430</span>
+      </div>
+  <div class="ext-desc">Just copied from Version 9/140430 of Remembering by Aaron Reed with &#39;Include Epistemology&#39; removed (because of incompatibilities with &#39;Conversation Package&#39;). Replaces &#39;You can&#39;t see any such thing&#39; for a seen but out-of-scope noun with a message acknowledging that the parser recognizes the object. With Glulx, also keeps track of where the player last saw that object.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Remembering%20IT.i7x"><span class='link'>Remembering IT by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;9/140531</span>
+      </div>
+  <div class="ext-desc">Translation in italian of Version 9/140430 of Remembering by Aaron Reed.
+
+Replaces &#39;You can&#39;t see any such thing&#39; for a seen but out-of-scope noun with a message acknowledging that the parser recognizes the object. With Glulx, also keeps track of where the player last saw that object.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Aaron%20Reed/Response%20Assistant.i7x"><span class='link'>Response Assistant by Aaron Reed</span></a>
+      </div>
+  <div class="ext-desc">Adds some helpful testing commands for changing default responses.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Matt%20Weiner/Responsive%20Disambiguation%20for%206M62.i7x"><span class='link'>Responsive Disambiguation for 6M62 by Matt Weiner</span></a>
+      </div>
+  <div class="ext-desc">Responsive Disambiguation is a plug-and-play extension; it should have its desired effect merely by including it. </div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Juhana%20Leinonen/Reversed%20Persuasion%20Correction.i7x"><span class='link'>Reversed Persuasion Correction by Juhana Leinonen</span></a>
+    &ensp;<span class="version">Version&nbsp;2</span>
+      </div>
+  <div class="ext-desc">Automatically corrects commands given to NPCs where the order is reversed, for example HELLO, ALICE instead of ALICE, HELLO.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Ron%20Newcomb/Rewrite%20the%20Command%20Line.i7x"><span class='link'>Rewrite the Command Line by Ron Newcomb</span></a>
+    &ensp;<span class="version">Version&nbsp;2/110202</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Allows us to erase then rewrite the commands our player types in.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Gavin%20Lambert/Rideable%20Vehicles.i7x"><span class='link'>Rideable Vehicles by Gavin Lambert</span></a>
+    &ensp;<span class="version">Version&nbsp;1/200619</span>
+      </div>
+  <div class="ext-desc">Improves how rideable vehicles and animals interact with other supporters.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Rideable%20Vehicles%20IT.i7x"><span class='link'>Rideable Vehicles IT by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;3</span>
+      </div>
+  <div class="ext-desc">Vehicles which one sits on top of, rather than inside, such as elephants or motorcycles. La traduzione in italiano è l&#39;unica modifica apportata rispetto all&#39;originale.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Emily%20Short/Room%20Description%20Control.i7x"><span class='link'>Room Description Control by Emily Short</span></a>
+    &ensp;<span class="version">Version&nbsp;13/160517</span>
+      </div>
+  <div class="ext-desc">A framework by which the author can considerably change the listing of objects in a room description. Includes facilities for concealing objects arbitrarily and changing the order in which objects are listed.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Daniel%20Stelzer/Runtime%20Replacements.i7x"><span class='link'>Runtime Replacements by Daniel Stelzer</span></a>
+      </div>
+  <div class="ext-desc">This utility extension allows players to define replacements to alter their own commands. It does not affect the world model or the game itself in any way, only the user interface.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Xavid/Scenery%20Words.i7x"><span class='link'>Scenery Words by Xavid</span></a>
+    &ensp;<span class="version">Version&nbsp;1/170913</span>
+      </div>
+  <div class="ext-desc">This extensions loops over all the rooms in your games and tries examining words in the room description to see how the game responds. This is designed to catch words players expect to be able to examine, but cannot due to author oversight.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Brady%20Garvin/Scopability.i7x"><span class='link'>Scopability by Brady Garvin</span></a>
+    &ensp;<span class="version">Version&nbsp;1</span>
+      </div>
+  <div class="ext-desc">The ability to toggle objects&#39; scopability; the parser does not acknowledge the existence of unscopable objects, even if they are explicitly added to scope.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Mike%20Ciul/Scope%20Caching.i7x"><span class='link'>Scope Caching by Mike Ciul</span></a>
+    &ensp;<span class="version">Version&nbsp;2/120725</span>
+      </div>
+  <div class="ext-desc">Gives things the &#39;marked visible&#39; property, to check the visibility of something without repeating the entire scope loop each time. Works with Epistemology by Eric Eve, Conditional Backdrops by Mike Ciul, and Remembering by Aaron Reed.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Ron%20Newcomb/Scope%20Control.i7x"><span class='link'>Scope Control by Ron Newcomb</span></a>
+    &ensp;<span class="version">Version&nbsp;2</span>
+      </div>
+  <div class="ext-desc">Allows us to ask why the Deciding the Scope For Something activity is running, so we can modify the scope only when we absolutely need to.  Highly useful for giving NPCs commands over telephones or while in darkness, creating &#39;can hear&#39; relations, or modifying how Inform parses the command line.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Scoring.i7x"><span class='link'>Scoring by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;1/140824</span>
+      </div>
+  <div class="ext-desc">About the score.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Scoring%20IT.i7x"><span class='link'>Scoring IT by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;1/140824</span>
+      </div>
+  <div class="ext-desc">About the score. Translated in Italian.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Andrew%20Owen/Secret%20Doors.i7x"><span class='link'>Secret Doors by Andrew Owen</span></a>
+      </div>
+  <div class="ext-desc">Doors and switches that cannot be acted upon until they are discovered.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Gavin%20Lambert/Secret%20Doors.i7x"><span class='link'>Secret Doors by Gavin Lambert</span></a>
+    &ensp;<span class="version">Version&nbsp;2</span>
+      </div>
+  <div class="ext-desc">Doors and switches that cannot be acted upon until they are discovered.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Andrew%20Plotkin/Serial%20And%20Fix.i7x"><span class='link'>Serial And Fix by Andrew Plotkin</span></a>
+      </div>
+  <div class="ext-desc">Allows commands of the form GET X, Y, AND Z to be parsed.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Emily%20Short/Simple%20Followers.i7x"><span class='link'>Simple Followers by Emily Short</span></a>
+    &ensp;<span class="version">Version&nbsp;7</span>
+      </div>
+  <div class="ext-desc">Allows non-player characters to follow the player (or one another); adds a FOLLOW command and a corresponding STOP FOLLOWING command so that the player can issue these orders to non-player characters. Adds adaptive text features.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Simple%20Followers%20IT.i7x"><span class='link'>Simple Followers IT by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;5</span>
+      </div>
+  <div class="ext-desc">Allows non-player characters to follow the player (or one another); adds a FOLLOW command and a corresponding STOP FOLLOWING command so that the player can issue these orders to non-player characters. Semplicemente tradotto in italiano.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Emily%20Short/Simple%20Graphical%20Window.i7x"><span class='link'>Simple Graphical Window by Emily Short</span></a>
+    &ensp;<span class="version">Version&nbsp;10/161003</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Provides a graphics window in one part of the screen, in which the author can place images; with provision for scaling, tiling, or centering images automatically. Glulx only.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Simple%20Graphical%20Window.i7x"><span class='link'>Simple Graphical Window by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;8/140908</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Provides a graphics window in one part of the screen, in which the author can place images; with provision for scaling, tiling, or centering images automatically, as well as setting a background color. Glulx only. Modified because of changes in 6L38 release.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Simple%20HTML%20Window.i7x"><span class='link'>Simple HTML Window by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;2/140731</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Provides an HTML window in the left part of the screen, in which the player may write anything. Glulx only.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Alice%20Grove/Simple%20Spelling.i7x"><span class='link'>Simple Spelling by Alice Grove</span></a>
+    &ensp;<span class="version">Version&nbsp;2/160807</span>
+      </div>
+  <div class="ext-desc">Simple Spelling aims to make stories more screen-reader-friendly by allowing players to request the spelling of any visible thing. This extension adds two actions: &#39;listing visible items for spelling&#39; and &#39;spelling the numbered word.&#39;</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Dannii%20Willis/Simple%20Unit%20Tests.i7x"><span class='link'>Simple Unit Tests by Dannii Willis</span></a>
+    &ensp;<span class="version">Version&nbsp;1/130803</span>
+      </div>
+  <div class="ext-desc">Very simple unit tests.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Shin/Singing%20Reloaded.i7x"><span class='link'>Singing Reloaded by Shin</span></a>
+    &ensp;<span class="version">Version&nbsp;1</span>
+      </div>
+  <div class="ext-desc">Singing as defined in Version 2/090402 of the Standard Rules by Graham Nelson.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Emily%20Short/Single%20Paragraph%20Description.i7x"><span class='link'>Single Paragraph Description by Emily Short</span></a>
+    &ensp;<span class="version">Version&nbsp;5</span>
+      </div>
+  <div class="ext-desc">A room description extension based on Room Description Control (which is required). All contents of a room are summarized in a single paragraph, starting with the regular room description.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Nels%20Olsen/Slotted%20Wearing%20and%20Wielding.i7x"><span class='link'>Slotted Wearing and Wielding by Nels Olsen</span></a>
+    &ensp;<span class="version">Version&nbsp;1/160118</span>
+      </div>
+  <div class="ext-desc">Requires armor, clothing and other worn and held items to occupy specific slots on the body.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Aaron%20Reed/Small%20Kindnesses.i7x"><span class='link'>Small Kindnesses by Aaron Reed</span></a>
+    &ensp;<span class="version">Version&nbsp;13/140501</span>
+      </div>
+  <div class="ext-desc">Provides a number of small interface improvements for players, understanding commands like GO BACK and GET IN, an EXITS command which automatically runs after failed movement, a USE verb, and more. Compatible with Modified Exit and Approaches by Emily Short, Keyword Interface by Aaron Reed, and Implicit Actions by Eric Eve.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Small%20Kindnesses%20IT.i7x"><span class='link'>Small Kindnesses IT by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;13/140529</span>
+      </div>
+  <div class="ext-desc">Translation in italian of version 13/140501 of Small Kindnesses by Aaron Reed.
+
+Provides a number of small interface improvements for players, understanding commands like GO BACK and GET IN, an EXITS command which automatically runs after failed movement, a USE verb, and more. Compatible with Modified Exit and Approaches by Emily Short, Keyword Interface by Aaron Reed, and Implicit Actions by Eric Eve.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Aaron%20Reed/Smarter%20Parser.i7x"><span class='link'>Smarter Parser by Aaron Reed</span></a>
+    &ensp;<span class="version">Version&nbsp;16/140501</span>
+      </div>
+  <div class="ext-desc">Understands a broader range of input than the standard parser, and can direct new players towards proper syntax.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Dave%20Robinson/Snippetage.i7x"><span class='link'>Snippetage by Dave Robinson</span></a>
+    &ensp;<span class="version">Version&nbsp;2</span>
+      </div>
+  <div class="ext-desc">Some functions for setting and use of snippets (parts of the player&#39;s command).</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Mike%20Ciul/Speech%20Motivations.i7x"><span class='link'>Speech Motivations by Mike Ciul</span></a>
+    &ensp;<span class="version">Version&nbsp;1/121204</span>
+      </div>
+  <div class="ext-desc">Player&#39;s thoughts and speech are expressed using the Thinking Privately and Speaking Out Loud activities. NPCs wait until end of turn rules to speak.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Alice%20Grove/Spelling%20for%20Screenreaders.i7x"><span class='link'>Spelling for Screenreaders by Alice Grove</span></a>
+    &ensp;<span class="version">Version&nbsp;1/201208</span>
+      </div>
+  <div class="ext-desc">This extension is unfinished. It is not recommended for general use.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Standard%20Inventory%20IT.i7x"><span class='link'>Standard Inventory IT by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;3/140824</span>
+      </div>
+  <div class="ext-desc">A less schematic inventory. In Italian.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Dannii%20Willis/Startup%20Precomputation.i7x"><span class='link'>Startup Precomputation by Dannii Willis</span></a>
+    &ensp;<span class="version">Version&nbsp;1/160718</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">A system for precomputing slow startup code</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Status%20Line.i7x"><span class='link'>Status Line by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;1/140824</span>
+      </div>
+  <div class="ext-desc">About the Status Line.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Jeff%20Nyman/Story%20Substrate.i7x"><span class='link'>Story Substrate by Jeff Nyman</span></a>
+    &ensp;<span class="version">Version&nbsp;1/200930</span>
+      </div>
+  <div class="ext-desc">Provides information about the substrate that a story is executing on.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Daniel%20Stelzer/Subcommands.i7x"><span class='link'>Subcommands by Daniel Stelzer</span></a>
+      </div>
+  <div class="ext-desc">Exposes the snippets referring to each noun.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Suggested%20Actions.i7x"><span class='link'>Suggested Actions by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;1/140823</span>
+      </div>
+  <div class="ext-desc">After examining a thing, this extension lists the possible actions.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Suggested%20Actions%20IT.i7x"><span class='link'>Suggested Actions IT by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;1/140823</span>
+      </div>
+  <div class="ext-desc">After examining a thing, this extension lists the possible actions. The commands are written in italian.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Jeff%20Nyman/Supplemental.i7x"><span class='link'>Supplemental by Jeff Nyman</span></a>
+    &ensp;<span class="version">Version&nbsp;1/200930</span>
+      </div>
+  <div class="ext-desc">Personal extension to keep the main source text clean.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Shin/Swearing%20Reloaded.i7x"><span class='link'>Swearing Reloaded by Shin</span></a>
+    &ensp;<span class="version">Version&nbsp;1</span>
+      </div>
+  <div class="ext-desc">Swearing as defined in Version 2/090402 of the Standard Rules by Graham Nelson.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Nathanael%20Nerode/Tab%20Removal.i7x"><span class='link'>Tab Removal by Nathanael Nerode</span></a>
+    &ensp;<span class="version">Version&nbsp;1/171007</span>
+      </div>
+  <div class="ext-desc">Rejects commands with tabs in them.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Emily%20Short/Tailored%20Room%20Description.i7x"><span class='link'>Tailored Room Description by Emily Short</span></a>
+    &ensp;<span class="version">Version&nbsp;13/180515</span>
+      </div>
+  <div class="ext-desc">An extension to go with Room Description Control, providing a different style of room description than the default. Parenthetical remarks such as (open) and (in which are...) are omitted in favor of full English sentences. Removes the requirement for Text Variations.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Mike%20Ciul/Takeability.i7x"><span class='link'>Takeability by Mike Ciul</span></a>
+    &ensp;<span class="version">Version&nbsp;1/110404</span>
+      </div>
+  <div class="ext-desc empty-desc"><span class="code">(I see no description here.)</span></div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Telephones%20IT.i7x"><span class='link'>Telephones IT by Leonardo Boselli</span></a>
+      </div>
+  <div class="ext-desc">Telephones, standard and portable. Solo tradotto in italiano.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Eric%20Eve/Text%20Capture.i7x"><span class='link'>Text Capture by Eric Eve</span></a>
+    &ensp;<span class="version">Version&nbsp;8</span>
+      </div>
+  <div class="ext-desc">Allows the capture of text that would otherwise be sent to the screen, so that the text can be further manipulated, displayed at some other point, or simply discarded. Version 6/120511 allows the use of unicode in Glulx.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Erik%20Temple/Text%20Window%20Input-Output%20Control.i7x"><span class='link'>Text Window Input-Output Control by Erik Temple</span></a>
+    &ensp;<span class="version">Version&nbsp;2/111114</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Allows authors to accept input in a separate window from output, or to redirect output to windows other the main window. Input and output windows can be changed during play. Also provides more control over transcript output. Requires Flexible Windows.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Daniel%20Stelzer/Third%20Noun.i7x"><span class='link'>Third Noun by Daniel Stelzer</span></a>
+      </div>
+  <div class="ext-desc empty-desc"><span class="code">(I see no description here.)</span></div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Chris%20Conley/Threaded%20Conversation.i7x"><span class='link'>Threaded Conversation by Chris Conley</span></a>
+    &ensp;<span class="version">Version&nbsp;7/180807</span>
+      </div>
+  <div class="ext-desc">A conversation system tracking facts known, phrases spoken, and subjects of conversation.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Daniel%20Stelzer/Threaded%20Conversation.i7x"><span class='link'>Threaded Conversation by Daniel Stelzer</span></a>
+      </div>
+  <div class="ext-desc">A conversation system tracking facts known, phrases spoken, and subjects of conversation.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Threaded%20Conversation%20IT.i7x"><span class='link'>Threaded Conversation IT by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;5/140605</span>
+      </div>
+  <div class="ext-desc">Translation in italian of Version 5/140601 of Threaded Conversation by Chris Conley.
+
+A conversation system tracking facts known, phrases spoken, and subjects of conversation.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Nathanael%20Nerode/Title%20Case%20for%20Headings.i7x"><span class='link'>Title Case for Headings by Nathanael Nerode</span></a>
+    &ensp;<span class="version">Version&nbsp;1/170902</span>
+      </div>
+  <div class="ext-desc">Applies title case to room names printed as a heading or in the status line.  Creates the printing a heading activity for further customization.  Tested with Inform 6M62.  Requires Undo Output Control by Erik Temple or by Nathanael Nerode to handle the case of room name printing after UNDO.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Gavin%20Lambert/Title%20Page.i7x"><span class='link'>Title Page by Gavin Lambert</span></a>
+    &ensp;<span class="version">Version&nbsp;1/200510</span>
+      </div>
+  <div class="ext-desc">Provides an intro screen to the story, offering an image and menu.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Jon%20Ingold/Title%20Page.i7x"><span class='link'>Title Page by Jon Ingold</span></a>
+    &ensp;<span class="version">Version&nbsp;4/200510</span>
+      </div>
+  <div class="ext-desc">Provides an intro panel to the game, offering a menu, a restore and restart prompt, a quotation and (under Glulx) a picture. Updated to version 3 for compatibility with Inform 6L02 and later by Emily Short.  Updated to version 4 by Gavin Lambert to fix an error with &#39;use skip intro&#39;.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Title%20Page%20IT.i7x"><span class='link'>Title Page IT by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;2</span>
+      </div>
+  <div class="ext-desc">Fornisce un pannello introduttivo al gioco, con un menù, la possibilità di caricare e ricominciare, una citazione e (in Glulx) una figura. Semplicemente tradotto dall&#39;originale.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Emily%20Short/Transit%20System.i7x"><span class='link'>Transit System by Emily Short</span></a>
+    &ensp;<span class="version">Version&nbsp;6</span>
+      </div>
+  <div class="ext-desc">Transit System provides a train-car kind which follows a schedule around the map, allowing the player or other characters to get on or off.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Mikael%20Segercrantz/Trinity%20Inventory.i7x"><span class='link'>Trinity Inventory by Mikael Segercrantz</span></a>
+    &ensp;<span class="version">Version&nbsp;5/070114</span>
+      </div>
+  <div class="ext-desc">Provides a framework for listing inventories in natural sentences, akin to Infocom&#39;s game Trinity. Separates carried and worn objects, followed by objects that contains other objects. What&#39;s listed in the third section is customizable via a rulebook. Objects can be marked as not listed when carried or worn as well as marked as having their contents listed in the inventory when they&#39;re empty. This extension is based upon the extension Written Inventory by Jon Ingold.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Trinity%20Inventory%20IT.i7x"><span class='link'>Trinity Inventory IT by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;5/140705</span>
+      </div>
+  <div class="ext-desc">Translation in italian of 5/070114 of Trinity Inventory by Mikael Segercrantz. Provides a framework for listing inventories in natural sentences, akin to Infocom&#39;s game Trinity. Separates carried and worn objects, followed by objects that contains other objects. What&#39;s listed in the third section is customizable via a rulebook. Objects can be marked as not listed when carried or worn as well as marked as having their contents listed in the inventory when they&#39;re empty. This extension is based upon the extension Written Inventory by Jon Ingold.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Emily%20Short/Tutorial%20Mode.i7x"><span class='link'>Tutorial Mode by Emily Short</span></a>
+    &ensp;<span class="version">Version&nbsp;5</span>
+      </div>
+  <div class="ext-desc">Adds a tutorial mode, which is on by default, to any game, to introduce key actions for the novice player. Can be revised or expanded by the author.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Tutorial%20Mode%20Hyperlinks.i7x"><span class='link'>Tutorial Mode Hyperlinks by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;2/140825</span>
+      </div>
+  <div class="ext-desc">Adds a tutorial mode, which is on by default, to any game, to introduce key actions for the novice player. Can be revised or expanded by the author. Changes to the original version: added the hyperlinks of the Hyperlink Interface. Based on Tutorial Mode by Emily Short.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Tutorial%20Mode%20Hyperlinks%20IT.i7x"><span class='link'>Tutorial Mode Hyperlinks IT by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;2/140825</span>
+      </div>
+  <div class="ext-desc">Adds a tutorial mode, which is on by default, to any game, to introduce key actions for the novice player. Can be revised or expanded by the author. Changes to the original version: added the hyperlinks of the Hyperlink Interface. Based on Tutorial Mode by Emily Short. Translated in Italian.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Daniel%20Stelzer/Typographical%20Conveniences.i7x"><span class='link'>Typographical Conveniences by Daniel Stelzer</span></a>
+      </div>
+  <div class="ext-desc empty-desc"><span class="code">(I see no description here.)</span></div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Dannii%20Willis/Ultra%20Undo.i7x"><span class='link'>Ultra Undo by Dannii Willis</span></a>
+    &ensp;<span class="version">Version&nbsp;1/160501</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Handles undo using external files for very big story files</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Eric%20Eve/Underside.i7x"><span class='link'>Underside by Eric Eve</span></a>
+    &ensp;<span class="version">Version&nbsp;6</span>
+      </div>
+  <div class="ext-desc">Allows objects to be put under other objects. An underside usually starts out closed so that its contents are hidden from view. Requires Version 7 (or later) of Bulk Limiter; the space under objects is limited by bulk. Underside is compatible with Version 10 or later of Implicit Actions, but does not require it. Version 5 of Underside avoids features deprecated in Version 6E59 of Inform.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Underside%20IT.i7x"><span class='link'>Underside IT by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;6/140530</span>
+      </div>
+  <div class="ext-desc">Translation in italian of version 6 of Underside by Eric Eve.
+
+Allows objects to be put under other objects. An underside usually starts out closed so that its contents are hidden from view. Requires Version 7 (or later) of Bulk Limiter; the space under objects is limited by bulk. Underside is compatible with Version 10 or later of Implicit Actions, but does not require it. Version 5 of Underside avoids features deprecated in Version 6E59 of Inform.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Erik%20Temple/Undo%20Output%20Control.i7x"><span class='link'>Undo Output Control by Erik Temple</span></a>
+    &ensp;<span class="version">Version&nbsp;5/170902</span>
+      </div>
+  <div class="ext-desc">In addition to allowing control over UNDO default messages, provides hooks into UNDO processing, including multiple ways to suspend UNDO temporarily, to place limitations on UNDO (such as allowing only one UNDO in a row), to undo the current turn from code, and to control when the game state is saved. Using the latter, we can effectively control which turn UNDO returns us to.  Also allows changing the words which invoke UNDO and OOPS.  Also allows the story to edit a blank command before analyzing it.  Updated to Inform 6M62.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Nathanael%20Nerode/Undo%20Output%20Control.i7x"><span class='link'>Undo Output Control by Nathanael Nerode</span></a>
+    &ensp;<span class="version">Version&nbsp;5/170902</span>
+      </div>
+  <div class="ext-desc">Provides hooks into UNDO processing, including multiple ways to suspend UNDO temporarily, to place limitations on UNDO (such as allowing only one UNDO in a row), to undo the current turn from code, and to control when the game state is saved. Using the latter, we can effectively control which turn UNDO returns us to.  Also allows changing the words which invoke UNDO and OOPS, and allows the story to edit a blank command before analyzing it.  Updated to Inform 6M62.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Andrew%20Plotkin/Unicode%20Parser.i7x"><span class='link'>Unicode Parser by Andrew Plotkin</span></a>
+    &ensp;<span class="version">Version&nbsp;7</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">When you include this extension, I7 will appear to behave as it always does. However, the command line will be read using a Unicode-friendly input call, and the internal parsing dictionary will contain Unicode strings instead of byte strings. This means that, theoretically, you can define nouns and verbs using any Unicode character (not just basic Latin-1.)</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Peter%20Orme/Unit%20Testing.i7x"><span class='link'>Unit Testing by Peter Orme</span></a>
+    &ensp;<span class="version">Version&nbsp;2/150205</span>
+      </div>
+  <div class="ext-desc">A developer extension that lets you write unit tests (asserts) in Inform 7.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Peter%20Orme/Universal%20Opening.i7x"><span class='link'>Universal Opening by Peter Orme</span></a>
+    &ensp;<span class="version">Version&nbsp;1/120223</span>
+      </div>
+  <div class="ext-desc">This extension provides you with testing commands for force opening things. The commands are all in sections marked as &quot;not for release&quot; - this is intended to be a tool during development and test, not for actual games. </div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Mike%20Ciul/Unknown%20Word%20Error.i7x"><span class='link'>Unknown Word Error by Mike Ciul</span></a>
+    &ensp;<span class="version">Version&nbsp;2/170531</span>
+      </div>
+  <div class="ext-desc">Provides Infocom-style parser messages such as &#39;I don&#39;t know the word &#39;kludge&#39;.&#39;</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Ron%20Newcomb/Unsuccessful%20PC%20Attempt.i7x"><span class='link'>Unsuccessful PC Attempt by Ron Newcomb</span></a>
+    &ensp;<span class="version">Version&nbsp;2</span>
+      </div>
+  <div class="ext-desc">Will run the Unsuccessful Attempt By rules for all characters, including the player.  Also silences the library messages printed by the built-in Check rules.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Eric%20Eve/Variable%20Time%20Control.i7x"><span class='link'>Variable Time Control by Eric Eve</span></a>
+    &ensp;<span class="version">Version&nbsp;4</span>
+      </div>
+  <div class="ext-desc">Allows individual actions to take a different number of seconds, or no time at all. Also allows the standard time taken per turn to be defined as so many seconds, which can be varied during the course of play</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Daniel%20Stelzer/Verbal%20Conjugation.i7x"><span class='link'>Verbal Conjugation by Daniel Stelzer</span></a>
+      </div>
+  <div class="ext-desc">This is a deceptively simple extension to conjugate action names. By default stored actions always print the present participle (&quot;taking the book&quot;), which can lead to awkward prose. This extension provides three phrases to help with this.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Xavid/Visible%20from%20a%20Distance.i7x"><span class='link'>Visible from a Distance by Xavid</span></a>
+    &ensp;<span class="version">Version&nbsp;1</span>
+      </div>
+  <div class="ext-desc">Allow certain things in adjacent rooms to be examined.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Daniel%20Gaskell/Volumetric%20Limiter.i7x"><span class='link'>Volumetric Limiter by Daniel Gaskell</span></a>
+    &ensp;<span class="version">Version&nbsp;2</span>
+      </div>
+  <div class="ext-desc">Containers and actor that limit their contents by volume. Modeled after Bulk Limiter by Eric Eve, but understands length, width, and height as well as total size.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Juhana%20Leinonen/Vorple.i7x"><span class='link'>Vorple by Juhana Leinonen</span></a>
+    &ensp;<span class="version">Version&nbsp;3/191117</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Core functionality of Vorple, including JavaScript evaluation and adding HTML elements.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Juhana%20Leinonen/Vorple%20Command%20Prompt%20Control.i7x"><span class='link'>Vorple Command Prompt Control by Juhana Leinonen</span></a>
+    &ensp;<span class="version">Version&nbsp;3/181103</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Manually triggering parser commands, changing the contents of the command prompt and manipulating the command history.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Juhana%20Leinonen/Vorple%20Element%20Manipulation.i7x"><span class='link'>Vorple Element Manipulation by Juhana Leinonen</span></a>
+    &ensp;<span class="version">Version&nbsp;3/181103</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Adding, removing, hiding, moving and other basic manipulation of HTML document elements.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Juhana%20Leinonen/Vorple%20Hyperlinks.i7x"><span class='link'>Vorple Hyperlinks by Juhana Leinonen</span></a>
+    &ensp;<span class="version">Version&nbsp;3/181103</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Hyperlinks that either open a web site, execute a parser command or evaluate JavaScript code.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Juhana%20Leinonen/Vorple%20Modal%20Windows.i7x"><span class='link'>Vorple Modal Windows by Juhana Leinonen</span></a>
+    &ensp;<span class="version">Version&nbsp;3/190914</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Modal windows are dialog prompts or other information windows that pop up on top of the play area and require user action to dismiss.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Juhana%20Leinonen/Vorple%20Multimedia.i7x"><span class='link'>Vorple Multimedia by Juhana Leinonen</span></a>
+    &ensp;<span class="version">Version&nbsp;3/191119</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Displaying images and playing sounds and music.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Juhana%20Leinonen/Vorple%20Notifications.i7x"><span class='link'>Vorple Notifications by Juhana Leinonen</span></a>
+    &ensp;<span class="version">Version&nbsp;3/181103</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Notifications that display a short message on the screen and disappear after a few seconds.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Juhana%20Leinonen/Vorple%20Screen%20Effects.i7x"><span class='link'>Vorple Screen Effects by Juhana Leinonen</span></a>
+    &ensp;<span class="version">Version&nbsp;3/181103</span>
+      </div>
+  <div class="ext-desc">Vorple equivalent of Basic Screen Effects by Emily Short. Waiting for a keypress, clearing the screen, aligning, styling and coloring text.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Juhana%20Leinonen/Vorple%20Status%20Line.i7x"><span class='link'>Vorple Status Line by Juhana Leinonen</span></a>
+    &ensp;<span class="version">Version&nbsp;3/181103</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">The Vorple version of the standard status line.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Juhana%20Leinonen/Vorple%20Tooltips.i7x"><span class='link'>Vorple Tooltips by Juhana Leinonen</span></a>
+    &ensp;<span class="version">Version&nbsp;3/181103</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Tooltips that can be activated on request or when the mouse cursor is moved over an element.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Written%20Inventory.i7x"><span class='link'>Written Inventory by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;3/140825</span>
+      </div>
+  <div class="ext-desc">Just Version 3 of Written Inventory by Jon Ingold made adaptive. Provides a framework for listing inventories in natural sentences. Separates carried and worn objects, followed by objects that contains other objects. What&#39;s listed in the third section is customisable via a rulebook.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Written%20Inventory%20IT.i7x"><span class='link'>Written Inventory IT by Leonardo Boselli</span></a>
+    &ensp;<span class="version">Version&nbsp;3/140824</span>
+      </div>
+  <div class="ext-desc">Just italian responses for Version 3 of Written Inventory by Jon Ingold. Provides a framework for listing inventories in natural sentences. Separates carried and worn objects, followed by objects that contains other objects. What&#39;s listed in the third section is customisable via a rulebook.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Dannii%20Willis/Xorshift.i7x"><span class='link'>Xorshift by Dannii Willis</span></a>
+    &ensp;<span class="version">Version&nbsp;1/140818</span>
+      </div>
+  <div class="ext-desc">Allows Inform 7&#39;s random number generator to be replaced with one that is consistent across all interpreters</div>
+  </div>
+</div>
+
+
+  <div class="error">
+  <h2>Errors</h2>
+  <details><summary>Omitted extensions and reasons</summary>
+  
+    <p class="omission"><a href="https://github.com/i7/extensions/blob/master/Daniel%20Stelzer/Hidden%20Prompt.i7x">Daniel Stelzer/Hidden Prompt.i7x</a>&emsp;Title or name mismatch with aHidden Prompt by Daniel Stelzer</p>
+  
+    <p class="omission"><a href="https://github.com/i7/extensions/blob/master/Dannii%20Willis/C.i7x">Dannii Willis/C.i7x</a>&emsp;Title or name mismatch with C by G</p>
+  
+    <p class="omission"><a href="https://github.com/i7/extensions/blob/master/Free%20Software%20Foundation/GNU%20General%20Public%20License%20v3.i7x">Free Software Foundation/GNU General Public License v3.i7x</a>&emsp;Title or name mismatch with the GNU General Public License v3 by Free Software Foundation</p>
+  
+    <p class="omission"><a href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Questions%20IT.i7x">Leonardo Boselli/Questions IT.i7x</a>&emsp;invalid byte sequence in UTF-8</p>
+  
+    <p class="omission"><a href="https://github.com/i7/extensions/blob/master/Leonardo%20Boselli/Simple%20Followers.i7x">Leonardo Boselli/Simple Followers.i7x</a>&emsp;Title or name mismatch with Simple Followers IT by Leonardo Boselli</p>
+  
+    <p class="omission"><a href="https://github.com/i7/extensions/blob/master/Marc%20von%20der%20Heiden/Distantly%20Visible%20Things_6G60.i7x">Marc von der Heiden/Distantly Visible Things_6G60.i7x</a>&emsp;Title or name mismatch with Distantly Visible Things by Marc Von Der Heiden</p>
+  
+    <p class="omission"><a href="https://github.com/i7/extensions/blob/master/Marc%20von%20der%20Heiden/Distantly%20Visible%20Things_6L02.i7x">Marc von der Heiden/Distantly Visible Things_6L02.i7x</a>&emsp;Title or name mismatch with Distantly Visible Things by Marc Von Der Heiden</p>
+  
+    <p class="omission"><a href="https://github.com/i7/extensions/blob/master/Mike%20Ciul/Automated%20Testing.i7x">Mike Ciul/Automated Testing.i7x</a>&emsp;Title or name mismatch with Automated Testing by Roger Carbol</p>
+  
+  </details>
+  </div>
+</main></body></html>

--- a/docs/informant/README.md
+++ b/docs/informant/README.md
@@ -1,0 +1,19 @@
+# Informant
+
+For the Friends of I7 Extensions Github Pages: given a Friends of I7 Extensions directory,
+it produces a stand-alone HTML page that lists the contents with links to the corresponding
+files on github.com.
+
+It writes to STDOUT; redirect as desired.
+
+With no command-line arguments, it assumes the current working directory is the extensions
+directory to operate on, e.g, within the extensions dir itself:
+
+    $ docs/informant/informant.rb > docs/index.html
+
+Optionally, the name of the extensions directory can specified as a command-line parameter,
+e.g., in one's docs directory:
+
+    $ ./informant/informant.rb .. > index.html
+
+For portability's sake, its only requirements are from Ruby's standard library.

--- a/docs/informant/informant.rb
+++ b/docs/informant/informant.rb
@@ -1,0 +1,137 @@
+#!/usr/bin/env ruby
+
+# informant by Zed Lopez begins here.
+
+extension_repo = 'https://github.com/i7/extensions'
+url_roots = { ext_root: 'blob/master', auth_root: 'tree/master' }
+
+$conf = Hash[ url_roots.map {|k,v| [ k, [ extension_repo, v ].join('/') ] } ]
+
+# for reference for potential future use
+# raw_ext_url_root: "https://raw.githubusercontent.com/i7/extensions/master"
+
+require 'uri'
+require 'erb'
+require 'pathname'
+
+globlist = [ '*', '*.i7x' ]
+if !ARGV.empty?
+  if ((ARGV.count > 1) or !File.directory?(ARGV.first))
+    STDERR.print("Usage: #{$0} [ extensions directory ]")
+    exit
+  end
+  globlist.unshift(ARGV.first)
+end
+
+ext_hash = {}
+errors = {}
+
+Dir[File.join(globlist)].each do |path|
+  ext_author, ext_filename = Pathname(path).each_filename.to_a.last(2)
+  ext_name  = ext_filename.delete_suffix('.i7x')
+  ext = { ext_author: ext_author, ext_name: ext_name, filename: ext_filename, desc: nil }
+  slurp = File.read(path)
+  begin
+    line = slurp.match(/\A([^\n\r]+)/).captures.first.strip
+    ext[:author] = (line.sub!(/(\s+by\s+(.+)\s+begins\s+here\s*\.)\Z/,'') ) ? $2 : nil
+    ext[:limiter] = (line.sub!(/(\s*\(\s*for\s+([-\w]+)\s+only\s*\))\Z/,'') ) ?  $2.capitalize : nil
+    ext[:version] = (line.sub!(/\A(\s*version\s+(.*?)\s+of\s+)/i,'') ) ?  $2 : nil
+    ext[:name] = line
+    # extension names are case-insensitive
+    unless ext[:name].downcase == ext[:ext_name].downcase and ext[:author] == ext[:ext_author]
+      errors[ext] = "Title or name mismatch with #{ext[:name]} by #{ext[:author]}"
+      next
+    end
+
+    ext[:desc] = $1 if slurp.match(/\A[^\n\r]+\s*(?:\[[^\]]*\]\s*)*"([^"]*)"/)
+    ext[:doc] = $1 if slurp.match(/---- DOCUMENTATION ----\s+(\S.*?)(\r?\n\r?\n|\Z)/i)
+    ext[:text] = ext[:desc] || ext[:doc]
+    
+  rescue StandardError => e
+    errors[ext] = e.message
+    next
+  end
+  ext_hash[ [ext_name,ext_author] ] = ext
+end
+
+# Ruby 2.7+ blares warnings to STDERR about URI.escape's deprecation hence rolling our own
+def uri_escape(str)
+  str.split(//).map {|c| c.match(URI::UNSAFE) ? sprintf('%%%02x',c.ord).upcase : c }.join
+end
+
+def auth_url(ext)
+  [ $conf[:auth_root], uri_escape(ext[:author])].join('/')
+end
+
+def ext_url(ext)
+  [ $conf[:ext_root], uri_escape(ext[:ext_author]), uri_escape(ext[:filename])].join('/')
+end
+
+erb = ERB.new(DATA.read, nil, '-') #0, '>')
+puts erb.result(binding)
+
+__END__
+<% h = CGI.method(:escapeHTML) -%>
+<!doctype html>
+<html lang="en"><head><meta charset="UTF-8"><title>Friends of I7 Extensions</title>
+<style>* { padding: 0; margin: 0 ; }
+html { font-size: 100%; }
+body { 
+color: #080808; 
+background-color: #FAFAFA;
+color: #0A0A0A;
+width: 41.5rem;
+margin: auto;
+font-size: 100%;
+margin-bottom: 2rem;
+} 
+h1.title { text-align: center; font-family: Constantia,Lucida Bright,Lucidabright,"Lucida Serif",Lucida,"DejaVu Serif","Bitstream Vera Serif","Liberation Serif",Georgia,serif; margin-top: 1rem; margin-bottom: 2rem; }
+div.ext-table { line-height: 1.5; font-family: Helvetica Neue,Helvetica,Arial,sans-serif; width: 40rem; margin-bottom: 2rem; }
+a.title { text-decoration-style: dotted; }
+div.ext-table-body { }
+hr.border { border: .05rem solid #333; margin: 1rem .5rem 1rem -1.5rem; }
+div.ext-name {  white-space: nowrap; width: 100%; margin-top: .1rem; font-size: 1.25rem; text-indent: -1.5rem; }
+div.ext-desc { margin-bottom: .5rem; padding-top: .25rem; }
+div.empty-desc { text-align: right; margin-right: .5rem; }
+a.ext { }
+span.link { font-weight: bold;} 
+span.version { font-size: 1rem; }
+span.limiter { font-style: italic; font-size: 1rem; }
+span.code { font-family: monospace; }
+div.error { margin-left: -1.5rem; }
+h2 { margin-top: 1rem; margin-bottom: 1rem; }
+details { border: .1rem solid black; padding: .5rem; }
+summary { margin: .5rem 0 .5rem 0; }
+p.omission { margin-bottom: .5rem; }
+</style>
+</head>
+<body><main>
+<h1 class="title"><a class="title" href="">Friends of I7 Extensions</a></h1>
+<div class="ext-table">
+<% ext_hash.values.sort_by {|b| [ b[:name].downcase, b[:author].downcase ] }.each do |ext| -%>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="<%= h.call(ext_url(ext)) %>"><span class='link'><%= h.call(ext[:name]) %> by <%= h.call(ext[:author]) %></span></a>
+  <% if ext[:version] -%>
+  &ensp;<span class="version">Version&nbsp;<%= h.call(ext[:version]) %></span>
+  <% end -%>
+  <% if ext[:limiter] -%>
+  &ensp;<span class="limiter">(for&nbsp;<%= h.call(ext[:limiter]) %>&nbsp;only)</span>
+  <% end -%>
+  </div>
+  <div class="ext-desc<% if ext[:text] %>"><%= h.call(ext[:text]) %><% else %> empty-desc"><span class="code">(I see no description here.)</span><% end %></div>
+  </div>
+<% end -%>
+</div>
+
+<% unless errors.empty? %>
+  <div class="error">
+  <h2>Errors</h2>
+  <details><summary>Omitted extensions and reasons</summary>
+  <% errors.keys.sort_by {|b| [ b[:ext_author], b[:filename] ] }.each do |ext| %>
+    <p class="omission"><a href="<%= h.call(ext_url(ext)) %>"><%= h.call(File.join(ext[:ext_author],ext[:filename])) %></a>&emsp;<%= h.call(errors[ext]) %></p>
+  <% end %>
+  </details>
+  </div>
+<% end -%>
+</main></body></html>


### PR DESCRIPTION
per prior disussion with Dannii, a script that can take an extensions repo dir and output an HTML page listing its contents sorted by extension name linking to their URLs on github, with their descriptions (or their first paragraph of ---- documentation ---- if no description is given).

Automatically listing their Includes and putting things that don't compile (i.e., a third of everything)  into the penalty box are under development, but this is useful as is and I wanted to get it out.