### PR TITLE
Repair command replacement in Glulx Entry Points

### DIFF
--- a/Dannii Willis/Glk Events.i7x
+++ b/Dannii Willis/Glk Events.i7x
@@ -32,8 +32,15 @@ The glk event value 2 variable translates into I6 as "GE_Event_Struct_val2".
 
 Section - The glulx input handling rules
 
+[Event handling without any bells or whistles]
+The glk event handling rules are a g-event based rulebook.
+
+[This rulebook was originally part of Glulx Entry Points.]
 The glulx input handling rules are a g-event based rulebook.
 
+[If Glulx Entry Points is not included, treat input handling rules as event processing rules.]
+A glk event handling rule for a g-event (called the event) (this is the glk event compatibility rule):
+	abide by the glulx input handling rules for the event.
 
 
 Section - Intercepting glk_select()
@@ -59,7 +66,7 @@ Include (-
 	! Run the glulx input handling rules (but disable rules debugging because it crashes if keyboard input events are pending)
 	@push debug_rules; @push say__p; @push say__pc;
 	debug_rules = false; ClearParagraphing(1);
-	FollowRulebook( (+ the glulx input handling rules +), GE_Event_Struct_type, true );
+	FollowRulebook( (+ the glk event handling rules +), GE_Event_Struct_type, true );
 	@pull say__pc; @pull say__p; @pull debug_rules;
 
 	! Copy back to the original event structure

--- a/Dannii Willis/Glk Events.i7x
+++ b/Dannii Willis/Glk Events.i7x
@@ -33,13 +33,13 @@ The glk event value 2 variable translates into I6 as "GE_Event_Struct_val2".
 Section - The glulx input handling rules
 
 [Event handling without any bells or whistles]
-The glk event handling rules are a g-event based rulebook.
+The glk event processing rules are a g-event based rulebook.
 
 [This rulebook was originally part of Glulx Entry Points.]
 The glulx input handling rules are a g-event based rulebook.
 
 [If Glulx Entry Points is not included, treat input handling rules as event processing rules.]
-A glk event handling rule for a g-event (called the event) (this is the glk event compatibility rule):
+A glk event processing rule for a g-event (called the event) (this is the glk event compatibility rule):
 	abide by the glulx input handling rules for the event.
 
 
@@ -66,7 +66,7 @@ Include (-
 	! Run the glulx input handling rules (but disable rules debugging because it crashes if keyboard input events are pending)
 	@push debug_rules; @push say__p; @push say__pc;
 	debug_rules = false; ClearParagraphing(1);
-	FollowRulebook( (+ the glk event handling rules +), GE_Event_Struct_type, true );
+	FollowRulebook( (+ the glk event processing rules +), GE_Event_Struct_type, true );
 	@pull say__pc; @pull say__p; @pull debug_rules;
 
 	! Copy back to the original event structure

--- a/Emily Short/Glulx Entry Points.i7x
+++ b/Emily Short/Glulx Entry Points.i7x
@@ -81,8 +81,8 @@ The glulx input handling rules have outcomes replace player input (success) and 
 To decide what number is the value returned by glk event handling (this is the handle glk event rule):
 	now glulx replacement command is "";
 	follow the glulx input handling rules for the GEP internal current glk event;
-	if the outcome of the rulebook is the replace player input outcome:
-		decide on GEP internal input replacement;
+	[if the outcome of the rulebook is the replace player input outcome:
+		decide on GEP internal input replacement;]
 	if the outcome of the rulebook is the require input to continue outcome:
 		decide on GEP internal input continuation;
 	follow the command-counting rules;
@@ -91,22 +91,35 @@ To decide what number is the value returned by glk event handling (this is the h
 		follow the command-showing rules;
 		follow the command-pasting rules;
 		if the [command-pasting] rule succeeded:
-			decide on GEP internal input replacement.
+			decide on GEP internal input replacement;
+	decide on GEP internal input continuation.
+
+GEP internal glk event result is a number that varies.
+	GEP internal glk event result is initially 0.
+
+[Take over handling of glulx events]
+The glk event compatibility rule is not listed in the glk event handling rules.
+
+A glk event handling rule (this is the glulx event handling rule):
+	Now GEP internal glk event result is the value returned by glk event handling.
 
 
 Section - HandleGlkEvent routine
 
 Include (- Array evGlobal --> 4; -) before "Glulx.i6t".
 
-[Include (- 
+To decide what number is the value returned by glk event result recalling (this is the unstash glk event rule):
+	decide on GEP internal glk event result.
+
+Include (- 
 
   [ HandleGlkEvent ev context abortres newcmd cmdlen i ;
       for (i=0:i<3:i++) evGlobal-->i = ev-->i;
       (+ library input context +) = context;
-      return (+ value returned by glk event handling +) ;
+      return (+ value returned by glk event result recalling +) ;
   ];
 
--) before "Glulx.i6t".]
+-) before "Glulx.i6t".
 
 
 Section - Useful function wrappers

--- a/Emily Short/Glulx Entry Points.i7x
+++ b/Emily Short/Glulx Entry Points.i7x
@@ -81,8 +81,8 @@ The glulx input handling rules have outcomes replace player input (success) and 
 To decide what number is the value returned by glk event handling (this is the handle glk event rule):
 	now glulx replacement command is "";
 	follow the glulx input handling rules for the GEP internal current glk event;
-	[if the outcome of the rulebook is the replace player input outcome:
-		decide on GEP internal input replacement;]
+	if the outcome of the rulebook is the replace player input outcome:
+		decide on GEP internal input replacement;
 	if the outcome of the rulebook is the require input to continue outcome:
 		decide on GEP internal input continuation;
 	follow the command-counting rules;

--- a/Emily Short/Glulx Entry Points.i7x
+++ b/Emily Short/Glulx Entry Points.i7x
@@ -98,9 +98,9 @@ GEP internal glk event result is a number that varies.
 	GEP internal glk event result is initially 0.
 
 [Take over handling of glulx events]
-The glk event compatibility rule is not listed in the glk event handling rules.
+The glk event compatibility rule is not listed in the glk event processing rules.
 
-A glk event handling rule (this is the glulx event handling rule):
+A glk event processing rule (this is the glulx event handling rule):
 	Now GEP internal glk event result is the value returned by glk event handling.
 
 


### PR DESCRIPTION
This PR restores some long-lost functionality for glulx command replacement in Glulx Entry Points.  Compatibility with existing extensions ought to be unaffected.

This restores the function of some dependent extensions such as the original Inline Hyperlinks by Daniel Stelzer.  (I have learned that Stelzer's extension has been supplanted by alternatives, but I was in too deep by that point!)

The problem is detailed here:  https://github.com/i7/extensions/issues/65

**Glk Events** is modified as follows:

- A new top-level rulebook called `the glk event processing rules` is added to **Glk Events**.
- That rulebook contains a compatibility rule that abides by the existing `glulx input handling rules`...

**Glulx Entry Points** (abbreviated GEP) is modified as follows:

- The compatibility rule in Glk Events is disabled when both extensions are included.
- A new glk event processing rule invokes **GEP**'s glk event handling function and stashes the event result.
- `HandleGlkEvent` is implemented by retrieving and returning the stashed event result.