### PR TITLE
Update extensions list as of 2022-05-08

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -318,6 +318,13 @@ Inform 7 project.</div>
   </div>
   <hr class="border">
   <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Zed%20Lopez/Bit%20Ops.i7x"><span class='link'>Bit Ops by Zed Lopez</span></a>
+    &ensp;<span class="version">Version&nbsp;2</span>
+      </div>
+  <div class="ext-desc">Routines to access bitwise operators. Tested on 6M62.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
   <a class='ext' href="https://github.com/i7/extensions/blob/master/Daniel%20Stelzer/Boolean%20Variables.i7x"><span class='link'>Boolean Variables by Daniel Stelzer</span></a>
       </div>
   <div class="ext-desc empty-desc"><span class="code">(I see no description here.)</span></div>
@@ -361,6 +368,13 @@ Containers and actors that limit their contents by bulk</div>
   </div>
   <hr class="border">
   <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Zed%20Lopez/Char.i7x"><span class='link'>Char by Zed Lopez</span></a>
+    &ensp;<span class="version">Version&nbsp;1</span>
+      </div>
+  <div class="ext-desc">Example: * Char</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
   <a class='ext' href="https://github.com/i7/extensions/blob/master/Nathanael%20Nerode/Character%20Portraits.i7x"><span class='link'>Character Portraits by Nathanael Nerode</span></a>
     &ensp;<span class="version">Version&nbsp;1/171007</span>
       </div>
@@ -385,6 +399,13 @@ Containers and actors that limit their contents by bulk</div>
     &ensp;<span class="version">Version&nbsp;5</span>
       </div>
   <div class="ext-desc">A simple system for building conversations.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Zed%20Lopez/Code.i7x"><span class='link'>Code by Zed Lopez</span></a>
+    &ensp;<span class="version">Version&nbsp;1</span>
+      </div>
+  <div class="ext-desc">You always need whitespace between operators and operands.</div>
   </div>
   <hr class="border">
   <div class="ext-entry"><div class="ext-name">
@@ -668,6 +689,14 @@ Provides a set of rules to facilitate defining default conversational responses 
   </div>
   <hr class="border">
   <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Dannii%20Willis/Data%20Structures.i7x"><span class='link'>Data Structures by Dannii Willis</span></a>
+    &ensp;<span class="version">Version&nbsp;1/220331</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Provides support for some additional data structures</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
   <a class='ext' href="https://github.com/i7/extensions/blob/master/Juhana%20Leinonen/Debug%20Files.i7x"><span class='link'>Debug Files by Juhana Leinonen</span></a>
     &ensp;<span class="version">Version&nbsp;2</span>
       &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
@@ -713,6 +742,13 @@ Provides a set of rules to facilitate defining default conversational responses 
     &ensp;<span class="version">Version&nbsp;1/150130</span>
       </div>
   <div class="ext-desc">Common definitions useful for Inform7 authors and extension developers.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/David%20A%20Wheeler/Dice.i7x"><span class='link'>Dice by David A Wheeler</span></a>
+    &ensp;<span class="version">Version&nbsp;1/220508</span>
+      </div>
+  <div class="ext-desc">Support conventional X d Y dice notation, e.g., 3 d 6 totals 3 six-sided dice.</div>
   </div>
   <hr class="border">
   <div class="ext-entry"><div class="ext-name">
@@ -934,7 +970,7 @@ Dishes is a convenience extension for use with Measured Liquid. It provides some
   <hr class="border">
   <div class="ext-entry"><div class="ext-name">
   <a class='ext' href="https://github.com/i7/extensions/blob/master/Jon%20Ingold/Flexible%20Windows.i7x"><span class='link'>Flexible Windows by Jon Ingold</span></a>
-    &ensp;<span class="version">Version&nbsp;15/220202</span>
+    &ensp;<span class="version">Version&nbsp;15/220305</span>
       &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
     </div>
   <div class="ext-desc">Exposes the Glk windows system so authors can completely control the creation and use of windows</div>
@@ -1490,6 +1526,13 @@ This extension emulates Blue Lacuna&#39;s emphasized keyword system for simplify
   </div>
   <hr class="border">
   <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Zed%20Lopez/List%20Utilities.i7x"><span class='link'>List Utilities by Zed Lopez</span></a>
+    &ensp;<span class="version">Version&nbsp;1/220327</span>
+      </div>
+  <div class="ext-desc">List utility functions</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
   <a class='ext' href="https://github.com/i7/extensions/blob/master/Emily%20Short/Location%20Images.i7x"><span class='link'>Location Images by Emily Short</span></a>
       &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
     </div>
@@ -1855,6 +1898,15 @@ Measured Liquid provides a concept of volume, together with the ability to fill 
   </div>
   <hr class="border">
   <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Zed%20Lopez/Parser%20Error%20Details.i7x"><span class='link'>Parser Error Details by Zed Lopez</span></a>
+    &ensp;<span class="version">Version&nbsp;1</span>
+      &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
+    </div>
+  <div class="ext-desc">Says where the parser ceased understanding a command, and describes
+ ways the dictionary does know how to use that verb. Tested on 6M62.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
   <a class='ext' href="https://github.com/i7/extensions/blob/master/Nathanael%20Nerode/Parser%20Error%20Number%20Bugfix.i7x"><span class='link'>Parser Error Number Bugfix by Nathanael Nerode</span></a>
     &ensp;<span class="version">Version&nbsp;1</span>
       </div>
@@ -2151,6 +2203,14 @@ Replaces &#39;You can&#39;t see any such thing&#39; for a seen but out-of-scope 
     &ensp;<span class="version">Version&nbsp;1/200619</span>
       </div>
   <div class="ext-desc">Improves how rideable vehicles and animals interact with other supporters.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Graham%20Nelson/Rideable%20Vehicles.i7x"><span class='link'>Rideable Vehicles by Graham Nelson</span></a>
+    &ensp;<span class="version">Version&nbsp;3/220311</span>
+      </div>
+  <div class="ext-desc">Vehicles which one sits on top of, rather than inside, such as elephants or
+motorcycles.</div>
   </div>
   <hr class="border">
   <div class="ext-entry"><div class="ext-name">
@@ -2479,6 +2539,13 @@ is marked Not for Release. For 6M62.</div>
   </div>
   <hr class="border">
   <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Zed%20Lopez/Switch.i7x"><span class='link'>Switch by Zed Lopez</span></a>
+    &ensp;<span class="version">Version&nbsp;2/220329</span>
+      </div>
+  <div class="ext-desc">A switch statement. Tested with 6M62.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
   <a class='ext' href="https://github.com/i7/extensions/blob/master/Nathanael%20Nerode/Tab%20Removal.i7x"><span class='link'>Tab Removal by Nathanael Nerode</span></a>
     &ensp;<span class="version">Version&nbsp;1/210314</span>
       </div>
@@ -2540,6 +2607,13 @@ tabulate action to show the contents of a table. For 6M62.</div>
       &ensp;<span class="limiter">(for&nbsp;Glulx&nbsp;only)</span>
     </div>
   <div class="ext-desc">Allows authors to accept input in a separate window from output, or to redirect output to windows other the main window. Input and output windows can be changed during play. Also provides more control over transcript output. Requires Flexible Windows.</div>
+  </div>
+  <hr class="border">
+  <div class="ext-entry"><div class="ext-name">
+  <a class='ext' href="https://github.com/i7/extensions/blob/master/Zed%20Lopez/Textile.i7x"><span class='link'>Textile by Zed Lopez</span></a>
+    &ensp;<span class="version">Version&nbsp;1/220331</span>
+      </div>
+  <div class="ext-desc">Text utility functions.</div>
   </div>
   <hr class="border">
   <div class="ext-entry"><div class="ext-name">
@@ -2734,9 +2808,9 @@ Allows objects to be put under other objects. An underside usually starts out cl
   <hr class="border">
   <div class="ext-entry"><div class="ext-name">
   <a class='ext' href="https://github.com/i7/extensions/blob/master/Zed%20Lopez/Unit%20Tests.i7x"><span class='link'>Unit Tests by Zed Lopez</span></a>
-    &ensp;<span class="version">Version&nbsp;1</span>
+    &ensp;<span class="version">Version&nbsp;7</span>
       </div>
-  <div class="ext-desc">Yet another Unit Tests extension. Tested with 6M62.</div>
+  <div class="ext-desc">For unit testing. Tested with 6M62.</div>
   </div>
   <hr class="border">
   <div class="ext-entry"><div class="ext-name">


### PR DESCRIPTION
Update the list of extensions in `docs/index.html`
as of 2022-05-08. This update was created using the instructions at
`docs/informant/README.md`, which say to run this:

~~~~sh
    docs/informant/informant.rb > docs/index.html
~~~~

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>