### PR TITLE
Fix documentation typo in "Dice" by David A Wheeler

### DIFF
--- a/David A Wheeler/Dice.i7x
+++ b/David A Wheeler/Dice.i7x
@@ -23,7 +23,7 @@ E.g., 3 d 6 totals 3 six-sided dice, while 4 d 8 + 7 totals 4 eight-sided dice (
 
 You may use this extension under the terms of the Creative Commons Attribution 3.0 United States (CC-BY-3.0-US) license, Creative Commons Attribution 4.0 International (CC-BY-4.0), OR the MIT license. See the source code for details.
 
-Exmple: * Pest Control - Dice in Action
+Example: * Pest Control - Dice in Action
 
 	"Pest Control" by David A Wheeler
 


### PR DESCRIPTION
Fix documentation typo in "Dice" by David A Wheeler.
This doesn't change the code, only its documentation, so
I'm leaving its version number unchanged.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>