### PR TITLE
Nathanael Nerode's extensions: Remove dummy variables which are no lo…

### DIFF
--- a/Nathanael Nerode/Gender Options-v4.i7x
+++ b/Nathanael Nerode/Gender Options-v4.i7x
@@ -1,4 +1,4 @@
-Version 4.0.220522 of Gender Options by Nathanael Nerode begins here.
+Version 4.0.220523 of Gender Options by Nathanael Nerode begins here.
 
 "More broad-minded English language gender/number model where male, female, and neuter are three separate true-false properties.  Allows for objects to respond to any specified combination of HE, SHE, IT, and THEY.  As fast as the Standard Rules.  Tested with Inform v10.1.0."
 
@@ -96,8 +96,9 @@ Chapter - Yourself Description (for use with Neutral Standard Responses by Natha
 
 Section SR2.3.11B - Deleted Yourself Description (in place of Section SR2.3.11B - Yourself Description in Gender Options by Nathanael Nerode)
 
-dummy_variable_1234567890 is a truth state that varies.
-[* We don't need to give a description, because Neutral Standard Responses does.  Unfortunately, there must be something, not a comment, in every section or bug 0001841 causes a compiler crash.  This is the smallest possible dummy we can create, occupying between 1 bit and 1 byte.]
+[ We don't need to give a description, because Neutral Standard Responses does. ]
+[ In Inform version 6M62 (9.3) and earlier, there must be something, not a comment, in every section or bug 0001841 causes a compiler crash.  This is the smallest possible dummy we can create, occupying between 1 bit and 1 byte.  this is unnecessary in Inform v10.]
+[ dummy_variable_1234567890 is a truth state that varies. ]
 
 Volume - Parser Modifications for Pronoun Handling
 
@@ -953,7 +954,8 @@ Gender Options is incompatible with Second Gender by Felix Larsson.  The two do 
 
 Section 8 - Changelog
 
-Version 4.0.220521  - Update for Inform v10.1.0, which restructured Standard Rules and the I6T code and the method of replacing I6T code.  Implement "unset pronouns from" in order to solve an issue noted on the forum without restricting options.  Many whitespace fixes.  New example game.  Make opaque persons possible.  Apply my Style Guide principles -- don't number the headings!
+Version 4.0.220523 - Eliminate now-unnecessary dummy variable.
+Version 4.0.220521 - Update for Inform v10.1.0, which restructured Standard Rules and the I6T code and the method of replacing I6T code.  Implement "unset pronouns from" in order to solve an issue noted on the forum without restricting options.  Many whitespace fixes.  New example game.  Make opaque persons possible.  Apply my Style Guide principles -- don't number the headings!
 Version 3/210331 - Fix example / testsuite.
 Version 3/170818 - Small documentation and comment tweaks.
 Version 3/170816 - Replaced "always" with "usually" for man and woman.  Eliminated implications which didn't work.  Moved "person is usually not neuter" into correct section.  Removed androgyne kind and collective noun property for efficiency (they were syntactic sugar).  Revised documentation, comments, and City Park exmaple.  Added "It for All" example.

--- a/Nathanael Nerode/Nathanael's Extension Style Guide.txt
+++ b/Nathanael Nerode/Nathanael's Extension Style Guide.txt
@@ -81,7 +81,11 @@ This is to avoid namespace conflicts with the game writer.  The game writer shou
 
 If you're defining a "drawer" kind, just call it a "drawer".  The game writer is going to have to write it repeatedly.  Likewise if you're defining a say-phrase for the game writer -- a say-phrase is a shorthand, so make its name short and clear.
 
-(13) To delete a section from another extension, replace it with a section containing nothing but a dummy variable.  Due to a bug in Inform 7 (6M62), you can't have a completely blank section.  There are examples of this in Gender Options ( search for dummy_variable_1234567890 ) and Title Case for Headings ( dummy_variable_97538642 ).
+(13) To delete a section from another extension, replace it with a section containing nothing.  In Inform 7 v10, this works.
+
+Often this is to avoid conflicts with other extensions, in which case it should be done inside a Chapter which selects based on whether that other extension is included.  There are examples in Gender Options and Title Case for Headings.  
+
+Due to a bug in version 6M62 and earlier of Inform 7, you can't have a completely blank section, so in 6M62, include a dummy variable.  There are examples of this in the 6M62/9.3 versions of Gender Options ( search for dummy_variable_1234567890 ) and Title Case for Headings ( dummy_variable_97538642 ).
 
 (14) Document your extension.
 

--- a/Nathanael Nerode/Title Case for Headings-v1.i7x
+++ b/Nathanael Nerode/Title Case for Headings-v1.i7x
@@ -1,4 +1,4 @@
-Version 1.2.220521 of Title Case for Headings by Nathanael Nerode begins here.
+Version 1.2.220522 of Title Case for Headings by Nathanael Nerode begins here.
 
 "Applies title case to room names printed as a heading or in the status line.  Creates the printing a heading activity for further customization.  Tested with Inform 10.1.0.  Requires Undo Output Control by Erik Temple or by Nathanael Nerode to handle the case of room name printing after UNDO."
 
@@ -112,8 +112,8 @@ Part - second implementation check (for use without Undo Output Control by Natha
 
 Section 5 - No Undo Fix (in place of Section 5 - Undo Fix in Title Case for Headings by Nathanael Nerode)
 
-[required to avoid compilation error]
-dummy_variable_97538642 is a truth state which varies.
+[required to avoid compilation error in 6M62 -- not needed in Inform v10 !  Yay!]
+[ dummy_variable_97538642 is a truth state which varies. ]
 
 
 Title Case for Headings ends here.
@@ -187,6 +187,15 @@ There is one annoying corner case.  When "undo" is successfully executed, the ro
 The newest version of Undo Output Control is on the "Friends of I7" extension page on Github.  I updated it specifically so that I could fix this bug.
 If you have trouble including Undo Output Control, you may just be willing to live with the bug.
 
+Section 5 - Changelog
+
+Version 1.2.220522: Example bugfix, remove unnecessary dummy variable, add Changelog
+Version 1.2.220521: Proper update to Inform v10
+Version 1.2: Partial update to Inform v10
+Version 1/170902: Version for inform 6M62
+
+Section 6 - Examples
+
 Example: * Meadow - The title is Meadow, the name is meadow
 
 The title in the status line and room description will be "Meadow".
@@ -251,8 +260,8 @@ names manually.
 	Instead of going to Pond-Center, say "[We]['re] not dressed for swimming."
 
 	After deciding the scope of an object (called character):
-	if the location of the character is a pond room:
-		Place Pond-Center in scope, but not its contents.
+		if the location of the character is a pond room:
+			Place Pond-Center in scope, but not its contents.
 
 	Pond-N, Pond-S, Pond-E, and Pond-W are pond rooms.
 	The title of Pond-N is "North of the Pond".


### PR DESCRIPTION
…nger necessary in Inform v10; fix one example in Title Case for Headings.

<!--

Thank you for adding or updating an extension!

This extension now requires all extensions for Inform 7 release 10.1 and 9.3 (6M62) to be production-ready. Any extensions for older Inform 7 releases or for experiments and works-in-progress, should be committed to the [master branch](https://github.com/i7/extensions/tree/master).

-->

Please ensure that you have followed these steps to make a pull request for 10.1 or 9.3 (6M62):

- [x ] This extension is stable and production-ready
  - Please also check that your extension only depends on other stable extensions which are supported for the target Inform 7 release. An extension which depends on extensions which are not stable cannot be accepted.
- [x ] This extension has a valid version number:
  - For 10.1: use [semantic versioning](https://semver.org/): `MAJOR.MINOR.PATCH`, ex: `2.1.0`. This means that the major version number must be incremented when and only when you make a change that is not backwards compatible.
  - For 9.3: use Inform's date based version number: `MAJOR/DATE`, ex: `2/220517`.
- [x ] This extension has the correct file name:
  - For 10.1: put the major version number at the end of the file name, ex: `Extension Name-v1.i7x`
  - For 9.3: do not include the version number, and the file name must match the extension's name as defined in the file exactly, ex:
    - File name: `Extension Name.i7x`
    - Extension begins: `Version 1/220517 of Extension Name by Author Name begins here.`
- [x ] This extension has documentation
- [x ] The correct branch (10.1 or 9.3) has been selected for this pull request
