### PR TITLE
Nathanael Nerode's extensions: Fix version number SNAFU

### DIFF
--- a/Nathanael Nerode/Nathanael's Cookbook-v6.i7x
+++ b/Nathanael Nerode/Nathanael's Cookbook-v6.i7x
@@ -1,4 +1,4 @@
-Version 5.3 of Nathanael's Cookbook by Nathanael Nerode begins here.
+Version 6.0.220522 of Nathanael's Cookbook by Nathanael Nerode begins here.
 
 "This is just a collection of documentation and worked examples illustrating various features of Inform.  There isn't much in the extension per se, but the examples in the documentation can be click-pasted in the Inform IDE for convenience."
 
@@ -101,6 +101,14 @@ and have one special rule which runs last and does not have that line -- this ru
 (1) Make sure there *isn't* a paragraph break.
 (2) Make sure there *is* a line break.
 (3) You can get a single line break from a paragraph break without a line break, but this is undesirable and always a bug.
+
+Section - Changelog
+
+	6.0.220522: First version for Inform 10.1.  Increment major version to deal with a version number SNAFU.
+
+Section - The Cookbook Proper
+
+Here is the main Cookbook.
 
 Example: * Line Breaks - Understand when Inform implicitly emits line breaks
 

--- a/Nathanael Nerode/Standard Rules Dead Code Removal-v2.i7x
+++ b/Nathanael Nerode/Standard Rules Dead Code Removal-v2.i7x
@@ -39,4 +39,3 @@ Section - Changelog
 
 	2.0.220521: Update to Inform v10.1, which renamed sections of the Standard Rules, largely for the better.
 	1: First version.
- of Standard Rules Dead Code Removal by Nathanael Nerode begins here.

--- a/Nathanael Nerode/Title Case for Headings-v2.i7x
+++ b/Nathanael Nerode/Title Case for Headings-v2.i7x
@@ -1,4 +1,4 @@
-Version 1.2.220522 of Title Case for Headings by Nathanael Nerode begins here.
+Version 2.0.220522 of Title Case for Headings by Nathanael Nerode begins here.
 
 "Applies title case to room names printed as a heading or in the status line.  Creates the printing a heading activity for further customization.  Tested with Inform 10.1.0.  Requires Undo Output Control by Erik Temple or by Nathanael Nerode to handle the case of room name printing after UNDO."
 
@@ -189,6 +189,7 @@ If you have trouble including Undo Output Control, you may just be willing to li
 
 Section 5 - Changelog
 
+Version 2.0.220522: Correct a version number SNAFU
 Version 1.2.220522: Example bugfix, remove unnecessary dummy variable, add Changelog
 Version 1.2.220521: Proper update to Inform v10
 Version 1.2: Partial update to Inform v10

--- a/Nathanael Nerode/Verb Stripping-v2.i7x
+++ b/Nathanael Nerode/Verb Stripping-v2.i7x
@@ -1,4 +1,4 @@
-Version 1.2.220521 of Verb Stripping by Nathanael Nerode begins here.
+Version 2.0.220521 of Verb Stripping by Nathanael Nerode begins here.
 
 "Removes a number of verbs from the standard rules; verbs which might cause confusion in a game whose theme is not adventure."
 
@@ -81,3 +81,8 @@ Likewise it removes attack and all its synonyms.
 It also removes "push", which actually is implemented for shoving objects from room to room.  This is probably not the most intuitive meaning of "push" in a socially oriented game.
 
 The selection of which verbs to leave was somewhat arbitrary, based on the game I was working on at the time.
+
+Changelog:
+
+	2.0.220521: Version for Inform v10 (after a version number snafu)
+	1/171007: Version for Inform 6M62


### PR DESCRIPTION
<!--

Thank you for adding or updating an extension!

This extension now requires all extensions for Inform 7 release 10.1 and 9.3 (6M62) to be production-ready. Any extensions for older Inform 7 releases or for experiments and works-in-progress, should be committed to the [master branch](https://github.com/i7/extensions/tree/master).

-->

Please ensure that you have followed these steps to make a pull request for 10.1 or 9.3 (6M62):

- [x ] This extension is stable and production-ready
  - Please also check that your extension only depends on other stable extensions which are supported for the target Inform 7 release. An extension which depends on extensions which are not stable cannot be accepted.
- [x ] This extension has a valid version number:
  - For 10.1: use [semantic versioning](https://semver.org/): `MAJOR.MINOR.PATCH`, ex: `2.1.0`. This means that the major version number must be incremented when and only when you make a change that is not backwards compatible.
  - For 9.3: use Inform's date based version number: `MAJOR/DATE`, ex: `2/220517`.
- [x ] This extension has the correct file name:
  - For 10.1: put the major version number at the end of the file name, ex: `Extension Name-v1.i7x`
  - For 9.3: do not include the version number, and the file name must match the extension's name as defined in the file exactly, ex:
    - File name: `Extension Name.i7x`
    - Extension begins: `Version 1/220517 of Extension Name by Author Name begins here.`
- [x ] This extension has documentation
- [x ] The correct branch (10.1 or 9.3) has been selected for this pull request
