### PR TITLE
Nathanael Nerode/Undo Output Control: best practice changes to examples

### DIFF
--- a/Nathanael Nerode/Undo Output Control-v6.i7x
+++ b/Nathanael Nerode/Undo Output Control-v6.i7x
@@ -1,4 +1,4 @@
-Version 6.0.220521 of Undo Output Control by Nathanael Nerode begins here.
+Version 6.0.220527 of Undo Output Control by Nathanael Nerode begins here.
 
 "Provides hooks into UNDO processing, including multiple ways to suspend UNDO temporarily, to place limitations on UNDO (such as allowing only one UNDO in a row), to undo the current turn from code, and to control when the game state is saved. Using the latter, we can effectively control which turn UNDO returns us to.  Also allows the story to edit a blank command before analyzing it.  Updated to Inform 10.1."
 
@@ -588,16 +588,12 @@ Unified Glulx Input has its own (superior) method for dealing with blank lines; 
 
 Section - Changelog
 
+	6.0.220527: Example cleanups to facilitate automated testing.
 	v6 - Update to Inform v10.1.0.  (Nathanael Nerode.)  Eliminate compatibility with Conditional Undo by Jesse McGrew.  Eliminate "undo word #1" in favor of new "Include (- -) replacing UNDO1__WD" syntax.
-
 	v5 - Add "undo the current turn", documentation, and example.  (Nathanael Nerode)  Integrate Empty Command Handling by Daniel Stelzer.  Make compatible with Unified Glulx Input.
-
 	v4 - Substantial updates by Nathanael Nerode.  Update to 6M62.  Fix bugs. Improve documentation.
-
 	v3 - Removed unnecessary check of the "before undoing an action" rulebook at the end of the game. This caused an UNDO typed at the end of the game to fail silently.
-
 	v2 - Added suspension of game state saving and the Breaking Glass and Purgatory examples. Also added the ability to change word constants. Fixed minor bug in operation of undo suspension.
-
 	v1 - Initial release.
 
 Section - Examples
@@ -653,6 +649,8 @@ Note that Inform saves the game state even for out-of-world actions, so if the p
 
 	*: "I Love the Sound of Breaking Glass"
 
+	The story author is Erik Temple.
+	The release number is 3.
 	Include Undo Output Control by Nathanael Nerode.
 	
 	Report undoing an action:
@@ -691,7 +689,7 @@ Note that Inform saves the game state even for out-of-world actions, so if the p
 	
 	Instead of reckless behavior:
 		say "The [noun] shatters into thousands of pieces.";
-		remove the noun from play;
+		now the noun is nowhere;
 		if the pile of broken glass is in the Laboratory:
 			say "[line break]The pile of broken glass is now a bit higher.";
 		otherwise:
@@ -715,7 +713,8 @@ Note that we warn the player before allowing her to save during this purgatorial
 
 	*: "Purgatory"
 
-	The release number is 3.
+	The story author is Erik Temple.
+	The release number is 4.
 
 	Include Undo Output Control by Nathanael Nerode.
 	
@@ -752,7 +751,7 @@ Note that we warn the player before allowing her to save during this purgatorial
 		otherwise:
 			rule fails.
 
-	test purgatory with "look / drink poison / look / look / undo / look"
+	test me with "look / drink poison / look / look / undo / look"
 			
 Example: ** Purgatory II - As an additional enhancement, we make an automatic undo attempt after the player has died.
 
@@ -760,7 +759,8 @@ Example: ** Purgatory II - As an additional enhancement, we make an automatic un
 
 	Include Undo Output Control by Nathanael Nerode.
 	
-	The release number is 2.
+	The story author is Erik Temple.
+	The release number is 3.
 	
 	Black Room is a room. There is a bottle of poison in Black Room.
 	
@@ -799,4 +799,4 @@ Example: ** Purgatory II - As an additional enhancement, we make an automatic un
 		otherwise:
 			rule fails.
 
-	test purgatory with "look / drink poison / look / look / look"
+	test me with "look / drink poison / look / look / look"


### PR DESCRIPTION
<!--

Thank you for adding or updating an extension!

This extension now requires all extensions for Inform 7 release 10.1 and 9.3 (6M62) to be production-ready. Any extensions for older Inform 7 releases or for experiments and works-in-progress, should be committed to the [master branch](https://github.com/i7/extensions/tree/master).

-->

Please ensure that you have followed these steps to make a pull request for 10.1 or 9.3 (6M62):

- [x ] This extension is stable and production-ready
  - Please also check that your extension only depends on other stable extensions which are supported for the target Inform 7 release. An extension which depends on extensions which are not stable cannot be accepted.
- [x ] This extension has a valid version number:
  - For 10.1: use [semantic versioning](https://semver.org/): `MAJOR.MINOR.PATCH`, ex: `2.1.0`. This means that the major version number must be incremented when and only when you make a change that is not backwards compatible.
  - For 9.3: use Inform's date based version number: `MAJOR/DATE`, ex: `2/220517`.
- [x ] This extension has the correct file name:
  - For 10.1: put the major version number at the end of the file name, ex: `Extension Name-v1.i7x`
  - For 9.3: do not include the version number, and the file name must match the extension's name as defined in the file exactly, ex:
    - File name: `Extension Name.i7x`
    - Extension begins: `Version 1/220517 of Extension Name by Author Name begins here.`
- [x ] This extension has documentation
- [x ] The correct branch (10.1 or 9.3) has been selected for this pull request
