### PR TITLE
Port Gavin Lambert's basic extensions

### DIFF
--- a/Gavin Lambert/Brief Room Descriptions-v1.i7x
+++ b/Gavin Lambert/Brief Room Descriptions-v1.i7x
@@ -1,4 +1,4 @@
-Version 1.3 of Brief Room Descriptions by Gavin Lambert begins here.
+Version 1.3.1 of Brief Room Descriptions by Gavin Lambert begins here.
 
 "Alters BRIEF mode to display a room's brief description instead of nothing."
 
@@ -39,7 +39,7 @@ It still respects player preferences, however, so if they explicitly request "ve
 
 The "superbrief" mode remains unaffected by this and will not display either kind of description.  We presume the player knows what they're doing if they request this.
 
-Example: * Brevity is Beautiful
+Example: * Brevity is Beautiful - Demonstration of brief descriptions.
 
 	*: "Brevity is Beautiful"
 	

--- a/Gavin Lambert/Enterable Underside-v2.i7x
+++ b/Gavin Lambert/Enterable Underside-v2.i7x
@@ -1,0 +1,330 @@
+Version 2.0.221220 of Enterable Underside by Gavin Lambert begins here.
+
+"Adds the ability to enter 'under' some object, such as hiding under a bed."
+
+"Inspired by and based on a forum post by Eric Conrad."
+
+Include Underside by Eric Eve.
+Include Prepositional Correctness by Gavin Lambert.
+
+Section - Misc Patches to other extensions
+
+The clever looking under rule response (A) is "Under [the noun] [is-are a list of locale-supportable things in the underpart]."
+
+Carry out placing something under something closed (this is the reveal underside contents when placing under rule):
+	[This doesn't actually list the contents of the underside, as the player has pushed an object in without looking.  But we
+	 do need to allow the objects underneath to be considered in scope, to let them refer to the object they just put there.]
+   now the u-side is open.
+
+To decide whether (obj - an object) is enclosed under/underneath/beneath (targetobj - a thing):
+	if the targetobj encloses an underside (called the underpart) which is part of the targetobj,  decide on whether or not the obj is enclosed by the underpart;
+	decide no.
+	
+Notionally-indirectly-underlying relates  a thing (called X) to a thing (called Y) when X is enclosed under Y.
+
+The verb to be enclosed under implies the notionally-indirectly-underlying relation.
+
+[This is a little bit of hammerspace logic -- if the player is somewhere where a large object won't fit, and yet are
+ still carrying that large object, they still shouldn't be allowed to drop it there.]
+Check an actor dropping (this is the can't drop what won't fit by bulk rule):
+	let the receptacle be the holder of the actor;
+	if the receptacle provides the property bulk capacity:
+		if the bulk of the noun is greater than the bulk capacity of the receptacle:
+			if the receptacle is an underside:
+				say "[The noun] [are] too big to fit under [the holder of the receptacle]." (A) instead;
+			otherwise:
+				say "[The noun] [are] too big to fit in [the receptacle]." (B) instead;
+		if the bulk of the noun is greater than the free capacity of the receptacle:
+			if the receptacle is an underside:
+				say "[There] [are not] enough room left under [the holder of the receptacle] for [the noun]."  (C) instead;
+			otherwise:
+				say "[There] [are not] enough room left in [the receptacle] for [the noun]."  (D) instead.
+  
+Section - Prepositional Correctness
+
+The verb to get under means the reversed containment relation.
+The verb to get out from under means the reversed containment relation.
+
+The preposition of an underside is usually "under".
+The printed name of an underside is usually "[preposition of the item described] [the holder of the item described]".
+The entering preposition of an underside is usually the verb get under.
+The exiting preposition of an underside is usually the verb get out from under.
+
+To say enter underneath to the (O - underside) -- running on:
+	say "[adapt entering preposition of O] [the holder of O]".
+
+To say entering underneath to the (O - underside) -- running on:
+	say "[present participle of entering preposition of O] [the holder of O]".
+
+To say exit underneath from the (O - underside) -- running on:
+	say "[adapt exiting preposition of O] [the holder of O]".
+
+To say exiting underneath from the (O - underside) -- running on:
+	say "[present participle of exiting preposition of O] [the holder of O]".
+
+Rule for room heading describing a thing (called the surrounding) when the player is enclosed under the surrounding (this is the standard underside preposition rule):
+	say printed name of the associated underside of surrounding.
+
+Section - Entering the Underside
+
+Entering underneath is an action applying to one thing.
+
+The specification of the entering underneath action is "Entering underneath is the action allowing the player to enter the 'underside' of some object -- whereas the regular 'entering' action applies to the top-side instead.  Note that the noun of this action is the object that incorporates the underside, not the underside itself.  By default this is not permitted unless the underside is marked as enterable."
+
+The entering underneath action has an object called the underside being entered.
+
+Setting action variables for entering underneath:
+	now the underside being entered is a random underside that is part of the noun.
+
+Check an actor entering underneath (this is the can't enter underneath something with no underside rule):
+	if the underside being entered is nothing:
+		if the actor is the player, say "[There's] no space under [regarding the noun][those]." (A);
+		stop the action.
+
+Check an actor entering underneath (this is the can't enter underneath something already entered rule):
+	let the local ceiling be the common ancestor of the actor with the underside being entered;
+	if the local ceiling is the underside being entered:
+		if the actor is the player, say "But [we]['re] already under [the noun]." (A);
+		stop the action.
+
+To enter is a verb.
+Check an actor entering underneath (this is the can't enter underneath something not enterable rule):
+	if the underside being entered is not enterable:
+		if the actor is the player, say "[We] [can't enter] [regarding the noun][those]." (A);
+		stop the action.
+		
+Check an actor entering underneath (this is the can't fit underneath something rule):
+	if the bulk of the actor > the bulk capacity of the underside being entered:
+		if the actor is the player, say "[We]['re] too big to fit under [the noun]." (A);
+		stop the action;
+	if the bulk of the actor > the free capacity of the underside being entered:
+		if the actor is the player, say "[There] [are not] enough room left under [the noun]." (B);
+		stop the action.
+
+Check an actor entering underneath (this is the implicitly pass underneath other barriers rule):
+	let the original noun be the noun;
+	now the noun is the underside being entered;
+	follow the implicitly pass through other barriers including undersides rule;
+	now the noun is the original noun;
+	if the rule failed, stop the action.
+
+Carry out an actor entering underneath (this is the standard enter underneath rule):
+	surreptitiously move the actor to the underside being entered.
+	
+Report an actor entering underneath (this is the standard report enter underneath rule):
+	if the actor is the player:
+		if the action is not silent:
+			say "[We] [enter underneath to the underside being entered]." (A);
+	otherwise:
+		say "[The actor] [enter underneath to the underside being entered]." (B);
+	continue the action.
+
+Report an actor entering underneath (this is the describe contents entered underneath rule):
+	if the actor is the player, try looking under the noun.
+
+Section - Exiting the Underside
+
+[Mostly the standard 'exit' action works fine for exiting *from* an underside, but we need to fix up the response.]
+
+Report an actor exiting when the container exited from is an underside (this is the standard report exiting underneath rule):
+	if the action is not silent:
+		if the actor is the player:
+			say "[We] [exit underneath from the container exited from]." (B);
+		otherwise:
+ 			say "[The actor] [exit underneath from the container exited from]." (C);
+		stop the action;
+	continue the action.
+	
+[We also need a bit of extra work to correctly exit *to* an underside, since normally Inform doesn't like exiting to parts.]
+
+Carry out an actor exiting when the holder of the container exited from is an underside (this is the standard underside exiting rule):
+	let the former exterior be the holder of the container exited from;
+	surreptitiously move the actor to the former exterior;
+	stop the action. [this still reports, it just prevents the standard carry out from running]
+
+Carry out an actor getting off when the holder of the noun is an underside (this is the standard underside getting off rule):
+	let the former exterior be the holder of the noun;
+	surreptitiously move the actor to the former exterior;
+	stop the action. [this still reports, it just prevents the standard carry out from running]
+
+Section - Underside Indirection
+
+[It really feels like there ought to be a better way to restructure Inform's world model than this.]
+
+Check an actor entering (this is the implicitly pass through other barriers including undersides rule):
+	if the holder of the actor is the holder of the noun, continue the action;
+	let the local ceiling be the common ancestor of the actor with the noun;
+	while the holder of the actor is not the local ceiling:
+		let the current home be the holder of the actor;
+		if the player is the actor:
+			if the current home is an underside:
+				say "([exiting underneath from the current home])[command clarification break]" (F);
+			otherwise if the current home is a supporter or the current home is an animal:
+				[say text of implicitly pass through other barriers rule response (A);]
+				say "([exiting the current home])[command clarification break]" (A);
+			otherwise:
+				[say text of implicitly pass through other barriers rule response (B);]
+				say "([exiting the current home])[command clarification break]" (B);
+		silently try the actor trying exiting;
+		if the holder of the actor is the current home, stop the action;
+	if the holder of the actor is the noun, stop the action;
+	if the holder of the actor is the holder of the noun, continue the action;
+	let the target be the holder of the noun;
+	if the noun is part of the target, let the target be the holder of the target;
+	while the target is a thing:
+		if the target is an underside and the holder of the target is in the local ceiling:
+			if the player is the actor, say "([entering underneath to the target])[command clarification break]" (G);
+			silently try the actor trying entering underneath the holder of the target;
+			if the holder of the actor is not the target, stop the action;
+			convert to the entering action on the noun;
+			continue the action;
+		otherwise if the holder of the target is the local ceiling:
+			if the player is the actor:
+				if the target is a supporter:
+					[say text of implicitly pass through other barriers rule response (C);]
+					say "([entering the target])[command clarification break]" (C);
+				otherwise if the target is a container:
+					[say text of implicitly pass through other barriers rule response (D);]
+					say "([entering the target])[command clarification break]" (D);
+				otherwise:
+					[say text of implicitly pass through other barriers rule response (E);]
+					say "(entering [the target])[command clarification break]" (E);
+			silently try the actor trying entering the target;
+			if the holder of the actor is not the target, stop the action;
+			convert to the entering action on the noun;
+			continue the action;
+		let the target be the holder of the target.
+		
+The implicitly pass through other barriers including undersides rule is listed instead of the implicitly pass through other barriers rule in the check entering rulebook.
+
+Section - Describing the Underside
+
+For printing a locale paragraph about a thing (called the roof) when the player is under the roof (this is the underside contents reporting rule):
+	if an underside (called the underpart) is part of the roof and a locale-supportable thing is in the underpart:
+		set pronouns from the roof;
+		repeat with possibility running through things in the underpart:
+			now the possibility is marked for listing;
+			if the possibility is mentioned:
+				now the possibility is not marked for listing;
+		increase the locale paragraph count by 1;
+		say "[capital preposition of the underpart] [the roof] " (A);
+		list the contents of the underpart, as a sentence, including contents,
+			giving brief inventory information, tersely, not listing
+			concealed items, prefacing with is/are, listing marked items only;
+		say ".[paragraph break]";
+	continue the activity.
+	
+Section - Not describing the Topside
+
+[This doesn't actually move the topside out of scope, so it's still possible to interact with things if you know they're there already.]
+
+Rule for choosing notable locale objects when the player is under something (called the roof) (this is the don't describe things on top when underneath rule):
+	repeat with item running through things held by the roof:
+		set the locale priority of the item to 0;
+	continue the activity.
+
+Enterable Underside ends here.
+
+---- DOCUMENTATION ----
+
+This extension is based on Underside by Eric Eve, extending that to support the player actually entering the underside of objects.
+
+It defines one new action, "entering underneath", which can move the player (or another actor) underneath any object that has had an underside created for it.  By default, this requires that the underside (specifically) has been declared as "enterable".
+
+Naturally, the space under things is often quite limited.  Underside uses the Bulk Limiter extension (also by Eric Eve) to manage this; see the documentation for that extension for more details on setting the "bulk" (size) of each object and the "bulk capacity" (available space) in the underside.  By default, entering underneath will only be allowed if there's enough free space in the underside for the actor to actually fit.  (Although note that a little bit of Hammerspace may apply here -- by default the player's inventory is not counted in their bulk, so they can quite happily enter underneath something while carrying something else too large to fit underneath.  You can fix this by carefully setting the player's bulk capacity (so that they cannot pick up enough things to not fit) and/or dynamically changing the player's bulk depending on their current inventory.)
+
+Note that this extension only introduces the new action -- it does not introduce any corresponding grammar to allow the player to actually perform it.  This is because depending on the specific objects in your story, different commands may make more sense than others.  You can define whatever commands you like; for example:
+	
+	Understand "hide under/beneath [something]" as entering underneath.
+
+You can alternatively trigger "try entering underneath bed" from some other command's rules, as you'd expect, even if you don't define any commands for it.
+
+You may also want to override the default response text to make it more suitable for the commands you're using, for example:
+	
+	can't enter underneath something not enterable rule response (A) is "[regarding the noun][Those] [aren't] something [we] [can] hide under."
+	
+Have a look at the "entering underneath" action in the Index for all the standard responses (and to quickly edit them using the 'set' link).
+
+Since this builds on top of Prepositional Correctness, you're also able to customise the "under" preposition used in the room heading when the player is underneath, or in room descriptions when other objects are:
+
+	The preposition of under#bed is "beneath".
+
+Example: * Hide and Seek - Hiding under beds, tables, or chairs.
+
+	*: "Hide and Seek"
+	
+	Include Enterable Underside by Gavin Lambert.
+	
+	Bedroom is a room.  It contains a small bed, a table, and a chair.
+	The bed is an enterable fixed in place supporter.
+	The table is an enterable fixed in place supporter.
+	The chair is an enterable fixed in place supporter.
+	Rule for room heading describing the bed: say "lying on a comfortable bed".
+
+	A fluffy pillow is on the bed.  The bulk is 2.
+
+	An enterable underside called under#bed is part of the bed.
+	The bulk capacity of under#bed is 5.  The bulk of the player is 4.
+	
+	An enterable underside called under#table is part of the table.
+	The bulk capacity of under#table is 3.
+	
+	A large blanket is in under#bed.  The bulk is 3.
+	A small stuffed bear is in under#bed.
+
+	Understand "hide under/beneath [something]" as entering underneath.
+
+	Test me with "hide under bed / look under bed / get blanket / hide under bed / l / exit".
+
+Example: * The Sweet Life - Also hiding under a bed, but with more drama.
+
+	*: "The Sweet Life" by Eric Conrad
+
+	Include Enterable Underside by Gavin Lambert.
+
+	Understand "hide under/underneath [something]" as entering underneath.
+
+	Bedroom is a room.
+
+	The bed is an enterable supporter.  It is in the bedroom.  The player is on the bed.  Angelina is a woman on the bed.
+
+	The under#bed is an underside.  It is part of the bed.  It is enterable and transparent.
+
+	The shoebox is a container.  It is in the under#bed.  Roberto is a man.  He is in the under#bed.
+
+	After looking under the bed for the first time:
+		say "'Angelina?  How could you -- with Roberto?'".
+
+	[ Two normal people can just fit under the bed provided there is nothing else there. ]
+	The bulk of a person is usually 5.
+
+	When play begins:
+		now the story viewpoint is first person singular;
+		say "[italic type](Dedicated to those dubbed Italian comedies from the early 1970s)[roman type][paragraph break]The door to the apartment slams shut.  From the hallway, the voice calls out 'Mi amore, I'm home.'  Panic-stricken, Angelina looks at me and whispers 'It's Giovanni.  Quickly, you must hide!'  Giovanni's steps grow softer as he walks toward the kitchen.  She breathes a sigh of relief as we hear the refrigerator open.  'Now hide.'  She points down, under the bed.".
+
+	Arrival is a scene.  Arrival begins when the player is in the under#bed.
+
+	When arrival begins:
+		say "As Giovanni enters the bedroom, he says, 'Mia cara!  It's so fine to be home.'  Angelina answers, 'O Giovanni, I missed you so.  Please buy some wine to celebrate!'[paragraph break]As her husband leaves for the store, she says, 'Both of you, out!'";
+		try Roberto exiting.
+
+	Test me with "exit / look under bed / hide under bed / take shoebox / hide under bed / exit".
+	
+Example: * A Nice Picnic - Spreading out a picnic blanket underneath a tree.
+
+Undersides are not really intended to model large spaces like this, since they deliberately conceal what lies underneath unless you're actively looking under.  But they can -- and until version 2 this sort of thing didn't work due to some quirks in how Inform handles entering and exiting things with component parts, so this serves as a demonstration that this has been worked around successfully.
+
+	*: "A Nice Picnic"
+	
+	Include Enterable Underside by Gavin Lambert.
+	
+	Picnic Area is a room.  "A bright open area close to a large tree.  [if the blanket is carried]You can either set up your picnic out in the open or under the tree.[end if]".
+	A large tree is scenery in Picnic Area.  The description is "An oak, you think."
+	An underside called under#tree is part of the tree.  It is enterable and transparent.  The preposition is "beneath".
+	The verb to go beneath means the reversed containment relation.  The entering preposition of under#tree is verb go beneath.
+	
+	The player carries a large checkered blanket and a small picnic basket.  The blanket is an enterable supporter.  The basket is a locked container.
+	
+	Understand "sit under/beneath [tree]" as entering underneath.
+
+	Test me with "put blanket under tree / sit on blanket / drop basket / l / exit / exit".

--- a/Gavin Lambert/Exit Lister-v4.i7x
+++ b/Gavin Lambert/Exit Lister-v4.i7x
@@ -1,4 +1,4 @@
-Version 4 of Exit Lister by Gavin Lambert begins here.
+Version 4.0.1 of Exit Lister by Gavin Lambert begins here.
 
 "Automatic listing of available exits, with a reasonable dose of customisation built in."
 
@@ -261,7 +261,7 @@ This example asks the player up front what they want to see in the exit list, in
 	The pink door is east of hallway and west of Bathroom. It is a door and scenery.
 	The description of the bathroom is "Everything in here is pink. The tiles on the walls, the toilet bowl, the bathtub, the floor, and even the ceiling. The only thing not pink is a large mirror on the wall, but since all it reflects is pink that hardly matters.".
 	A large mirror is scenery in bathroom. Instead of examining mirror, say "Don't be vain, you look fine.".
-        Rule for listing exits when the location is Bathroom: say "All this pink numbs your brain, and you can't remember how you got here."
+		Rule for listing exits when the location is Bathroom: say "All this pink numbs your brain, and you can't remember how you got here."
 
 	The brown door is west of hallway and east of the Living Room. It is a door and scenery. The closed text of the brown door is "(barred)".
 	The description of the living room is "You are in a well decorated room here, there are numerous pictures on the walls, some comfy looking chairs, and a big television set."
@@ -345,4 +345,7 @@ For ease of testing the different behaviour, this example also asks the player w
 		otherwise try turning exits off;
 		say "[paragraph break]You can always turn the exit list on or off with the commands EXITS ON and EXITS OFF. You can also always ask for an exit list with the command EXITS.[paragraph break]";
 
-	Test me with "w / x door / pull lever / x wall / pull lever / w"
+	[The first of these is for testing interactively, as when pasting this example.  The others are for automated testing in an extension project.]
+	Test me with "w / x door / pull lever / x wall / pull lever / w".
+	[Test me with "y / w / x door / pull lever / x wall / pull lever / w".]
+	[Test me with "n / w / x door / pull lever / x wall / pull lever / w".]

--- a/Gavin Lambert/Extended Banner-v5.i7x
+++ b/Gavin Lambert/Extended Banner-v5.i7x
@@ -1,0 +1,144 @@
+Version 5.0.1 of Extended Banner by Gavin Lambert begins here.
+
+"More control over what is printed in a banner, including an easily-included copyright line."
+
+"based on Version 4 by Stephen Granade"
+
+Section 1
+
+Include (-
+
+[ I7BuildVersion;
+	print (PrintI6Text) I7_VERSION_NUMBER;
+#ifdef DEBUG;
+	print " / D";
+#endif; ! DEBUG
+];
+
+-)
+
+Section 1G (for Glulx only)
+
+Include (-
+
+[ SerialNumber i;
+	for (i=0 : i<6 : i++) print (char) ROM_GAMESERIAL->i;
+];
+
+-)
+
+Section 1Z (for Z-machine only)
+
+Include (-
+
+[ SerialNumber i;
+	for (i=0 : i<6 : i++) print (char) HDR_GAMESERIAL->i;
+];
+
+-)
+
+Section 2
+
+To decide if (s - text) is blank: if s is "", yes; no.
+To decide if (s - text) is not blank: if s is not "", yes; no.
+
+[The extended story headline is necessary so that, if the author doesn't set the story headline value, "An Interactive Fiction" is printed out.]
+To say extended story headline: (- TEXT_TY_Say(Headline); -).
+To say story serial number: (- SerialNumber(); -).
+To say I7 version number: (- I7BuildVersion(); -).
+
+The story copyright string and story rights statement are text variables.
+
+Printing the story copyright line is an activity.
+
+Last rule for printing the story copyright line (this is the standard story copyright rule):
+	if the story copyright string is not blank:
+		say "Copyright [unicode 169] [story copyright string][if story author is not blank] by [story author][end if][line break]";
+		if the story rights statement is not blank, say "[story rights statement]";
+		otherwise say "All rights reserved";
+		say "[line break]";
+	rule succeeds.
+
+Last rule for printing the banner text (this is the extended banner rule):
+	say "[bold type][story title][roman type][line break][extended story headline][if story author is not blank] by [story author][end if][line break]";
+	carry out the printing the story copyright line activity;
+	say "Release [release number] / Serial number [story serial number] / Inform 7 v[I7 version number][line break]";
+	rule succeeds.
+
+Extended Banner ends here.
+
+---- DOCUMENTATION ----
+
+Extended Banner provides all of the tools necessary to rewrite the banner that is printed when a game begins.
+
+It was originally written by Stephen Granade; but in version 5, Gavin Lambert updated it to compile in 6M62 and made it easier to entirely replace the copyright line.
+Version 5.0.1 is an update to make it compatible with 10.1.2.
+
+By default it does nothing but define several new text substitutions: the extended story headline, the story serial number, and the I7 version number. For example, the following rule would print a version of the banner that's the same as the default one:
+
+	Rule for printing the banner text:
+		say "[bold type][story title][roman type][line break][extended story headline][if story author is not blank] by [story author][end if][line break]Release [release number] / Serial number [story serial number] / Inform 7 v[I7 version number][line break]" instead.
+
+The "if story author is not blank" text substitution uses a new phrase that determines whether or not a piece of text is blank.
+
+For additional examples of customisations, see below.
+
+Example: * Defaults - A simple demonstration of the defaults.
+
+The default behaviour is exactly the same as if you hadn't even included the extension, so this is not especially interesting as an example, but it's useful for automated testing.  (Albeit with the caveat that intest ignores the release banner, so some manual comparison is still needed.)
+
+	*: "Defaults" by Gavin Lambert
+
+	Include Extended Banner by Gavin Lambert.
+	
+	There is a room.
+
+Example: * Copyright - Adding some copyright text to the banner.
+
+To add a copyright line to the banner, you don't have to write a rule like the one above. Instead, you can define the story copyright string with the year or years for which you're claming copyright:
+
+	*: "Copyright" by Gavin Lambert
+	
+	Include Extended Banner by Gavin Lambert.
+	
+	The story copyright string is "2022".
+
+	There is a room.
+
+Example: * Explicitly Licensed - Adding some explicit license text as well.
+
+You can also change the rights you are claiming by changing the story rights string (this is only printed if you specify the story copyright string):
+
+	*: "Explicitly Licensed" by Gavin Lambert.
+	
+	Include Extended Banner by Gavin Lambert.
+
+	The story copyright string is "2022".
+	The story rights statement is "Released under the Creative Commons Attribution-NonCommercial-ShareAlike 2.5 License".
+	
+	There is a room.
+
+By default the story rights statement is "All rights reserved".
+
+Example: * Further Customization - Adjusting the copyright line in more depth.
+
+If you have something more complicated to say for your copyright statement, you can replace or adjust the "printing the story copyright line" activity:
+
+	*: "Further Customization" by Gavin Lambert.
+	
+	Include Extended Banner by Gavin Lambert.
+
+	The story copyright string is "1823".
+	
+	Rule for printing the story copyright line:
+		say "Based on a true story originally written by Suspicious Badger in [story copyright string]." instead.
+		
+	Before printing the story copyright line:
+		say "An anarchic kerfuffle."
+		
+	After printing the story copyright line:
+		say "You can discuss this story in the forum at https://my.awesome.website/."
+
+	There is a room.
+
+Note that if you replace the default story copyright line rule then it won't print the story copyright string or story rights statement, but you can still use these in your own rule.

--- a/Gavin Lambert/Prepositional Correctness-v2.i7x
+++ b/Gavin Lambert/Prepositional Correctness-v2.i7x
@@ -1,4 +1,4 @@
-Version 2.3 of Prepositional Correctness by Gavin Lambert begins here.
+Version 2.3.1 of Prepositional Correctness by Gavin Lambert begins here.
 
 "Provides a way to customise the prepositions used to refer to containment or support, and perhaps other custom relationships added by other extensions."
 
@@ -127,7 +127,7 @@ Prepositional Correctness ends here.
 
 Chapter - Compatibility
 
-This extension was written for Inform 6M62.  Since it delves heavily into Standard Library messages it is likely incompatible with any other version of Inform, but YMMV.
+This extension was written for Inform 6M62 and verified with Inform 10.1.2.  Since it delves heavily into Standard Library messages it is likely incompatible with any other version of Inform, but YMMV.
 
 It does not depend on any other extensions, but does introduce some extra features to enhance "Rideable Vehicles by Graham Nelson" if you happen to be using that as well.
 
@@ -198,7 +198,15 @@ The response text for several actions (notably, the "putting it on" and "inserti
 
 If you want to recognise additional custom prepositions in player commands, then you will need to define additional commands and/or amend the grammar yourself.  Since Inform's parser is (in general) a left-to-right one, it isn't really feasible to have these parse using a preposition property for a not-yet-known second noun.
 
-Example: * Excessive Comfort
+Chapter - Using with non-English languages
+
+While this is heavily based on the English language version of the Standard Rules, it should in theory be feasible to provide similar support for other languages, provided they at least follow a somewhat similar grammatical structure.  This requires writing another extension that either entirely replaces this, or includes this along with a replacement section thusly:
+	
+	Section - Another Language (in place of Section - English Language in Prepositional Correctness by Gavin Lambert)
+	
+	Your definitions go here.
+
+Example: * Excessive Comfort - Hiding in a closet, draping on a sofa, and lying on a bed.
 
 	*: "Excessive Comfort"
 	
@@ -241,7 +249,7 @@ Example: * Excessive Comfort
 
 	Test me with "enter closet / l / close closet / l / open closet / sit on sofa / l / sit on bed / l".
 
-Example: * Horseback
+Example: * Horseback - Riding a horse with Rideable Vehicles.
 
 	*: "Horseback"
 	

--- a/Gavin Lambert/Rideable Vehicles-v1.i7x
+++ b/Gavin Lambert/Rideable Vehicles-v1.i7x
@@ -1,4 +1,4 @@
-Version 1.3 of Rideable Vehicles by Gavin Lambert begins here.
+Version 1.3.1 of Rideable Vehicles by Gavin Lambert begins here.
 
 "Improves how rideable vehicles and animals interact with other supporters."
 
@@ -20,7 +20,7 @@ It was inspired by the thread https://intfiction.org/t/limiting-requiring-vehicl
 
 The "Back to the Hoverboard" example was inspired by Matt Weiner's post in the same thread.
 
-Example: * Back to the Hoverboard
+Example: * Back to the Hoverboard - Riding on a hoverboard.
 
 	*: "Back to the Hoverboard"
 	

--- a/Gavin Lambert/Title Page-v1.i7x
+++ b/Gavin Lambert/Title Page-v1.i7x
@@ -1,0 +1,280 @@
+Version 1.0.1 of Title Page by Gavin Lambert begins here.
+
+"Provides an intro screen to the story, offering an image and menu."
+
+Part - Dependencies
+
+Include Basic Screen Effects by Emily Short. 
+
+Part - Definitions
+
+Use hidden title page translates as (- Constant Hide_title; -).
+Use left aligned title page translates as (- Constant Left_align_title; -).
+Use art in title page translates as (- Constant Title_art; -).
+
+To say (n - number) spaces -- running on:
+	(- spaces ({n}); -)
+	
+Title page display rules is a rulebook.
+
+Section - Standard Rules
+
+A title page display rule (this is the title page name rule):
+	let line1 be "[bold type][story title][roman type]" (A);
+	if the left aligned title page option is active:
+		say line break;
+		say line1;
+	otherwise:
+		center line1;
+	
+A title page display rule (this is the title page author rule):
+	let line be "  by [if story author is empty]Anonymous[otherwise][story author][end if]" (A);
+	if the left aligned title page option is active:
+		say line break;
+		say line;
+	otherwise:
+		center line;
+	
+A title page display rule (this is the title page quotation rule):
+	let line be "[italic type][story headline][roman type]" (A);
+	if the left aligned title page option is active:
+		say line break;
+		say line;
+	otherwise:
+		center line;
+
+Part - Menu
+
+Section - Standard Menus
+
+Table of title page menu options
+left	right
+"Quit"	"Q"
+"                - from a saved position"	"R"
+"Start the story - from the beginning"	"(SPACE)"
+
+Table of title page menu actions
+number	rule
+32	title page start rule
+13	title page start rule
+-6	title page start rule
+82	restore the game rule
+114	restore the game rule
+77	title page quit rule
+109	title page quit rule
+
+Section - Menu Rules
+
+This is the title page start rule:
+	rule succeeds.
+	
+This is the title page quit rule:
+	stop game abruptly.
+
+Section - Menu Internals - unindexed
+
+To decide which number is the maximum of (a - number) and (b - number):
+	if a is greater than b, decide on a;
+	decide on b.
+
+To print the title page menu:
+	say paragraph break;
+	let width be the screen width;
+	let leftmax be 0;
+	let rightmax be 0;
+	repeat through table of title page menu options:
+		let leftmax be the maximum of leftmax and the number of characters in left entry;
+		let rightmax be the maximum of rightmax and the number of characters in right entry;
+	if leftmax plus rightmax plus 8 is greater than width:
+		[the screen is too narrow, fall back on basic formatting]
+		repeat through table of title page menu options in reverse order:
+			say "[left entry] : [right entry][line break]";
+	otherwise:
+		let gutter be 2;
+		if the left aligned title page option is not active:
+			[these parentheses are required, at least as of 6M62, since I7 fails basic arithmetic]
+			let gutter be (((width minus leftmax) minus rightmax) minus 4) divided by 2;
+		repeat through table of title page menu options in reverse order:
+			say "[fixed letter spacing][gutter spaces][left entry][fixed letter spacing][leftmax minus number of characters in left entry spaces] : [(rightmax minus number of characters in right entry) divided by 2 spaces][right entry][line break]";
+		say variable letter spacing.
+					
+Part - Splash Art (for Glulx only)
+
+Include Glulx Image Centering by Emily Short. 
+
+Title page figure is a figure-name variable.
+
+This is the title page splash art rule:
+	say paragraph break;
+	if the left aligned title page option is active:
+		display title page figure;
+	otherwise:
+		display title page figure centered;
+
+The title page splash art rule is listed before the title page quotation rule in the title page display rules.
+The title page splash art rule does nothing if the art in title page option is not active.
+
+Part - To do the thing
+
+Section - internals - unindexed
+
+To redraw status line:
+	(- DrawStatusLine(); -).
+	
+Section - Main
+
+First when play begins rule (this is the title page begin display rule):
+	while 1 is 1:
+		redraw status line;
+		clear the screen;
+		follow the title page display rules;
+		say line break;
+		print the title page menu;
+		let k be 0;
+		while k is 0:
+			let k be the chosen letter;
+			if there is a number of k in the table of title page menu actions:
+				follow the rule corresponding to a number of k in the table of title page menu actions;
+				if rule succeeded:
+					clear the screen;
+					say line break;
+					make no decision;
+				if rule failed:
+					let k be 0.
+
+Part - Or not to do the thing (not for release)
+
+The title page begin display rule does nothing if the hidden title page option is active.
+
+Part - Keep the Status Tidy (for use with Flexible Windows by Jon Ingold)
+
+The when play begins rulebook has a truth state called the prior title page status.
+
+First when play begins (this is the open the status window after title page rule):
+	if the prior title page status is true:
+		open the status window.
+		
+First when play begins rule (this is the close the status window before title page rule):
+	now the prior title page status is whether or not the status window is g-present;
+	if the prior title page status is true:
+		close the status window.
+		
+The title page begin display rule is listed before the open the status window after title page rule in the when play begins rulebook.
+		
+Part - Keep Graphics in its Place (for use with Simple Graphical Window by Emily Short)
+
+[Opening the status window after the graphics window is a bad idea, as then it ends up in the middle of the screen.]
+The graphics window construction rule is listed after the open the status window after title page rule in the when play begins rulebook.
+
+Title Page ends here.
+
+---- DOCUMENTATION ----
+
+This adds a title page to the start of your story -- heavily inspired by Jon Ingold's extension of the same name, but using a very different method of control.  (So you are very likely to need source text changes to switch from one to the other.)
+
+Simply including the extension, without doing anything else, nets you a startup display of your story's name, author, and headline, then asking the player to press a key to decide if they want a clean start or to restore a saved game.
+
+Of course, that can be annoying while you're developing your story, so it's possible to hide the title page in testing builds simply by including the following in your story (note that you can always define this, it is automatically ignored for release builds and you don't have to restrict it to "not for release" yourself -- you only need to remove it when you want to test something specifically about the title page):
+
+	Use hidden title page.
+	
+By default, everything in the title page is shown centred (or at least as centred as interpreters will allow).  If you instead prefer for things to be left-aligned, then you can say that:
+	
+	Use left aligned title page.
+	
+Example: * Simple Defaults - Basic title page
+
+	*: "Simple Defaults"
+	
+	Include Title Page by Gavin Lambert.
+	
+	Limbo is a room.
+	
+Example: * Splash - Title page with splash image
+
+If you're compiling to Glulx, then you can also include an image in the title page, by including the "Use art in title page" statement.  By default, it will appear between the story name/author and the headline, and it will use the cover art for your story (as defined by "Release along with cover art").  However note that cover art doesn't actually exist until the story is released, so you'll see a blank space instead while testing.  Otherwise, you can specify any other figure that you like (and these will appear while testing) by setting the "title page figure".
+
+Note that due to technical limitations, some interpreters (at time of writing, notably Quixe - the default web interpreter - was one of these) may still show this image left-aligned even when that option isn't set.  If this happens with your primary intended interpreter, then you may want to set the left alignment option so that everything appears consistent at least.
+
+Also at time of writing some additional steps are required after releasing before Quixe can load any image files, as it doesn't have access to the full blorb file.
+
+	*: "Splash" by Gavin Lambert
+
+	The story headline is "A Graphic Adventure".  Limbo is a room.
+	
+	Include Title Page by Gavin Lambert.  Use art in title page.
+	Figure splash is the file "splash.png" ("A colossal cave.").  The title page figure is figure splash.
+
+Example: * Additional accreditation - Customising the title page display
+
+The "title page display rules" are a rulebook that control the display of the top part of the title page.  As such, this means that you can do many different things to customise it.
+
+One of the simplest changes is to alter the response text for one of the standard rules to print something different instead.  It's also possible to reorder rules, omit them entirely, or introduce your own custom rules.
+
+Note that for best results, you should define rules with simple headers, and if you have conditions on applicability you should put them in the body of the rule.  Otherwise Inform may order the rules in a way that surprises you.
+
+	*: "Additional accreditation"
+	
+	Include Title Page by Gavin Lambert.  Limbo is a room.
+	
+	Use left aligned title page.  Use art in title page.
+	
+	The title page name rule is not listed in any rulebook.
+	The title page author rule is listed before the credit where credit is due rule in the title page display rules.
+	The title page author rule response (A) is "Created by an infinite array of monkeys with typewriters."
+	
+	A title page display rule (this is the credit where credit is due rule):
+		say "Some additional credits go to the lab members who were able to not only assemble, but also feed, all those monkeys.".
+
+Note that due to the way rulebooks work, you'll usually have better luck listing which rule it should appear before rather than after.  (And in this case we could have just disabled the author rule as well and written a new one rather than changing its text, but it serves as a demonstration of different customisations this way.)
+	
+Example: *** Extra Info - Customising the title page menu
+
+The menu at the bottom of the title page, on the other hand, is customised via tables.  (I did think of a way to control it via rulebooks instead, so I'm open to suggestions to change this if people have a strong preference for that.  Let me know.)  It's fairly straightforward to add new items to the top of the menu simply by continuing the table -- note that in order to make continuation easy, the table is printed in reverse order.  There's two tables involved; one has the display text and the other has the actions to be performed.
+
+Another possibility, instead of continuing the standard tables, is to amend them, or even to replace them entirely (by specifying a replacement Section).
+
+When writing the action rules, it's possible to manipulate the title page menu itself in a few ways:
+
+Firstly, if you write "rule succeeds", then this will end the title page and it will clear the screen and continue on with the rest of the normal "when play begins" rules.  (Use caution if you're calling a standard rule instead of writing one specifically for the title page.)  This may be suitable if you want to have the player choose between different starting conditions (such as different playable characters or genders) and you don't want to have a separate menu for that later on.
+
+If you write "rule fails", then it will go straight back to waiting for a menu keypress without updating the display.  (You should only do this if your rule doesn't say anything.  Again, use caution if you're re-using an existing rule.)
+
+If you write "make no decision" (or don't write any of these), then it will clear the screen and redisplay the title page menu.  (And it's possible for you to amend the tables to change the options before it does so, if you wish.)
+
+	*: "Extra Info"
+	
+	Include Glulx Text Effects by Emily Short.  [Include Flexible Windows by Jon Ingold.]
+	Include Title Page by Gavin Lambert.  Include Menus by Dannii Willis.  Limbo is a room.
+
+	Table of title page menu options (continued)
+	left	right
+	"Introduction for new players"	"N"
+
+	Table of title page menu actions (continued)
+	number	rule
+	78	new player intro rule
+	110	new player intro rule
+	
+	Table of New Player Info
+	title	submenu	text
+	"Special Commands"	--	"This game has a VERBS command. At any time, VERBS will list verbs that you could use in play."
+	"Warnings"	--	"This game contains Strong Language and Graphic Violence. It may not be suitable for younger audiences. Please use your own discretion in deciding whether this is right for you."
+
+	This is the new player intro rule:
+		display the Table of New Player Info menu with title "New Player Introduction".
+
+Note that the rule makes no decision (by default), in order to trigger redrawing the title page.  You will typically want to do that in all such rules.  Also note that both the upper and lower-case character codes are listed in the actions table.
+
+This example uses Menus by Dannii Willis purely for illustrative purposes; you can use any other menu framework or non-menu-related action rule that you wish.
+
+This example used to demonstrate integration with Flexible Windows by Jon Ingold, however this has not yet been ported to Inform 10.  But in theory when present, it will entirely hide the status window while the title page is shown and then show it again (or not, as appropriate) afterwards.  Menus by Dannii Willis is ok with this, but it's possible some other custom rules may want to do things involving the status window that aren't expecting it to be closed.  If this is a problem, then you can disable these rules with:
+	
+	*: The close the status window before title page rule is not listed in any rulebook.
+		The open the status window after title page rule is not listed in any rulebook.
+
+Another possibility is that after exiting the title page, some rules that open other windows may get confused by the status window opening and closing.  Again, the above can disable that entirely, but another possible solution is to ensure that the rules are processed in the correct order.  For example, the following line is automatically used to ensure compatibility with Simple Graphical Window by Emily Short; you may need something similar for other extensions.  (You shouldn't need it for anything done in your own story file, as that will naturally occur after the extensions by default anyway.)
+
+	*: The graphics window construction rule is listed after the open the status window after title page rule in the when play begins rulebook.
+
+You may need to similarly move rules around, or change the order in which you Include extensions, if some other extensions define "first when play begins" rules.  In general, "Title Page" works best as the last extension that you include; you should not need to do anything special in that case.


### PR DESCRIPTION
This updates most of my 6M62 extensions to work better in 10.1 (some were already done but had errors in the docs or other oddities).

The rest depend on Glk fundamentals that don't appear to be ported to 10.1 yet.  I did actually successfully get several of these dependencies compiling ok (in particular "Alternative Startup Rules", "Glk Events", "Glk Object Recovery", and "Glulx Entry Points"), but hit a brick wall in "Flexible Windows" because I couldn't figure out the new syntax for `{win}.(+ ref number +)`.  Let me know if you're interested in any of that WIP.

**Edit**: Actually, I think I figured out the syntax after all, or at least a clunky workaround.  The result almost but not quite works -- the status bar is mysteriously not inverted.