### PR TITLE
More reasonable formatting of the prefix-ask and prefix-say rules

### DIFF
--- a/Chris Conley/Threaded Conversation-v9.i7x
+++ b/Chris Conley/Threaded Conversation-v9.i7x
@@ -433,10 +433,10 @@ Rule for listing plausible quips (this is the standard quip plausibility rule):
 			say "[quip-suggestion-phrase][the prepared list delimited in disjunctive style]." (A);
 
 Before printing the name of a questioning quip while listing plausible quips or listing peripheral quips (this is the prefix-ask rule):
-	say "ask " (A).
+	say "[regarding the player][ask] about " (A).
 
 Before printing the name of an informative quip while listing plausible quips or listing peripheral quips (this is the prefix-say rule):
-	say "say " (A).
+	say "[regarding the player][tell] about " (A).
 
 
 Part Two - Customizing Listing Plausible Quips


### PR DESCRIPTION
Updates to the prefix-ask and prefix-say rules, such that

> ask topic

and

> say topic

become

> You could ask about topic

and

> You could tell about topic