### PR TITLE
Update GTE for Inform 11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 releases
+*.interb
 *~

--- a/Emily Short/Glulx Text Effects-v6_0_0.i7xd/Documentation/Documentation.md
+++ b/Emily Short/Glulx Text Effects-v6_0_0.i7xd/Documentation/Documentation.md
@@ -1,0 +1,92 @@
+Glulx Text Effects provides an easy way to set up special text effects for Glulx.
+
+Styles in Glulx
+---------------
+
+Unlike the Z-Machine, which allows arbitrary combinations of features (such as color and boldness) to be applied to text, Glulx requires the author to define and then use text styles. (Though note that through a common extension of Glk, per-character formatting is now supported in many Glulx interpreters).
+
+There are eleven of these styles:
+
+| Style name | Explanation |
+|------------|-------------|
+| normal-style | the style used for regular text |
+| italic-style | used for italic text (this is what the `[italic type]` phrase uses) |
+| bold-style | used for bold text (this is what the `[bold type]` phrase uses) |
+| fixed-letter-spacing-style | used for monospaced text (this is what the `[fixed letter spacing]` phrase uses) |
+| alert-style | used when printing an end of game message such as "\*\*\* You have died. \*\*\*" |
+| blockquote-style | used for printing box quotations |
+| header-style | used to print the title of the game |
+| input-style | used for the player's own input |
+| note-style | used for messages such as "[Your score has increased by one point.]" |
+| special-style-1 | these two styles are not used by Inform, and you are free to use them for any purpose you want |
+| special-style-2 | |
+
+Additionally, when defining styles you can set `all-styles` which will define all eleven styles at once.
+
+Defining styles
+---------------
+
+To define the appearance of each style, add a table continuation to the Table of User Styles in your code. For example:
+
+```
+Table of User Styles (continued)
+window	style name	color	italic	relative size
+all-buffer-windows	all-styles	#FF0000	true	--
+all-buffer-windows	header-style	#0000FF	false	1
+all-buffer-windows	special-style-1	#00FF00
+```
+
+This definition table above will make everything red and italics, except for the title (header) which will be blue and a size bigger. Special style 1 is set to green, but it won't be used without the author manually turning it on.
+
+Your table continuation does not need to include every column in the Table of User Styles, nor does it need to define every style. You can also continue the table multiple times, and even define a style in multiple places; if you do then the definitions will be combined together. If you do not want to set a feature for a style you can leave it blank with `--`.
+
+Styles are applied from most general to most specific. So `all-windows` styles are applied before `all-buffer-windows` styles, and `all-styles` before a specific style like `header-style`.
+
+Specifying styles through table columns
+---------------------------------------
+
+Each row of the Table of User Styles can have the following columns:
+
+| Feature | Kind | Explanation |
+|---------|------|-------------|
+| window | glk window | specifies which type of window to apply the styles to. Can be set to `all-windows`, `all-buffer-windows` (the default), or `all-grid-windows`. (Setting to a specific window, such as the `main window`, is not supported in this extension, but is supported in Flexible Windows by Jon Ingold.) |
+| background color | RGB colour | specifies the background color of the text |
+| color | RGB colour | specifies the color of the text itself |
+| fixed width | truth state | If true then the text will be displayed with a fixed width (monospace) font |
+| font weight | | specifies the weight of the font. Can be set to `light-weight`, `regular-weight` (the default), or `bold-weight` |
+| indentation | number | specifies the number of units of indentation for the whole block of text. Units are defined by interpreter, but are often equivalent to spaces |
+| first line indentation | number | specifies additional (or negative) indentation for the first line of the text block |
+| italic | truth state | If true then the text will be displayed in italics |
+| justification | | can be set to `left-justified`, `center-justified`, `right-justified`, or `left-right-justified` for justified on the left and right (often called full justification) |
+| relative size | number | specifies how many font sizes above or below the browser's default a style should be set to |
+| reversed | truth state | If true then the foreground and background colors of the text will be reversed. This is most commonly used for the status line |
+
+Colors are defined by specifying a RGB colour. RGB colors specify the red/green/blue components of a color in hexadecimal, and a correctly specified color will be 6 characters long, for example: `#00FF00`. Note that shortcut CSS colors (`#000`) are not supported.
+
+Not all interpreters support all of these features. Notably, Gargoyle does not support justification or font sizes. If the interpreter does not support one of the features it will just be quietly ignored. On the other hand, some interpreters don't support setting any stylehints at all, most notably Lectrote.
+
+Using the styles
+----------------
+
+You may invoke the text styles by using the following phrases
+
+| Style name | Phrase |
+|------------|--------|
+| normal-style | `[roman type]` |
+| italic-style | `[italic type]` |
+| bold-style | `[bold type]` |
+| fixed-letter-spacing-style | `[fixed letter spacing]` (Return to regular variable spaced type with either `[variable letter spacing]` or just `[roman type]`) |
+| alert-style | `[alert style]` |
+| blockquote-style | `[blockquote style]` |
+| header-style | `[header style]` |
+| input-style | `[input style]` |
+| note-style | `[note style]` |
+| special-style-1 | `[special-style-1]`, `[first special style]`, `[first custom style]`, etc. (there are multiple options to support older code) |
+| special-style-2 | `[special-style-2]`, `[second special style]`, `[second custom style]`, etc. |
+
+About this extension
+--------------------
+
+This extension was originally by Emily Short. Since version 5 it has been maintained by Dannii Willis.
+
+The latest version of this extension can be found at <https://github.com/i7/extensions>. This extension is released under the Creative Commons Attribution licence. Bug reports, feature requests or questions can be made at <https://github.com/i7/extensions/issues>.

--- a/Emily Short/Glulx Text Effects-v6_0_0.i7xd/Documentation/Examples/Gaudy.txt
+++ b/Emily Short/Glulx Text Effects-v6_0_0.i7xd/Documentation/Examples/Gaudy.txt
@@ -1,0 +1,31 @@
+Example: * Gaudy - A visually overpowering exercise in modifying all the built-in text styles.
+
+	*: "Gaudy"
+	
+	Include Glulx Text Effects by Emily Short.	
+	
+	Use scoring.
+	
+	Texty Room is a room. "This is a room of [bold type]bold[roman type] and [italic type]italic[roman type] texts as well as messages in [fixed letter spacing]fixed width[variable letter spacing] text."
+	
+	Table of User Styles (continued)
+	style name	relative size	color	background color
+	italic-style	-1	#0000FF [ blue ]	--
+	fixed-letter-spacing-style	--	#444444 [ dark-grey ]	--
+	header-style	10	--	--
+	bold-style	2	#888888 [ medium-grey ]	#80DAEB
+	alert-style	5	#FF0000 [ red ]
+	note-style	--	#00FF00 [ green ]
+	blockquote-style	--	#FFFF00 [ yellow ]
+	input-style	-1	#FF00FF [ magenta ]
+	
+	Instead of waiting:
+		increase the score by 5.
+	
+	Instead of jumping:
+		end the story finally.
+	
+	Every turn:
+		display the boxed quotation "Tempus fugit." 
+	
+	Test me with "z / z / z / jump".

--- a/Emily Short/Glulx Text Effects-v6_0_0.i7xd/Documentation/Examples/TheGallicWar.txt
+++ b/Emily Short/Glulx Text Effects-v6_0_0.i7xd/Documentation/Examples/TheGallicWar.txt
@@ -1,0 +1,26 @@
+Example: ** The Gallic War - An excuse to print a large, fancily-formatted bit of text using custom styles.
+
+	*: "The Gallic War" by Julius Caesar.
+	
+	The story headline is "An interactive campaign".
+	
+	Lessons is a room.
+	
+	Include Glulx Text Effects by Emily Short.
+	
+	Table of User Styles (continued)
+	style name	justification	italic	indentation	first line indentation	font weight	color
+	special-style-2	left-right-justified	true	15	-4	light-weight	#888888 [ medium-grey ]
+	
+	When play begins:
+		now the left hand status line is "";
+		now right hand status line is "";
+		say "[second custom style]Gallia est omnis divisa in partes tres, quarum unam incolunt Belgae, aliam Aquitani, tertiam qui ipsorum lingua Celtae, nostra Galli appellantur. Hi omnes lingua, institutis, legibus inter se differunt. Gallos ab Aquitanis Garumna flumen, a Belgis Matrona et Sequana dividit. 
+	
+Horum omnium fortissimi sunt Belgae, propterea quod a cultu atque humanitate provinciae longissime absunt, minimeque ad eos mercatores saepe commeant atque ea quae ad effeminandos animos pertinent important, proximique sunt Germanis, qui trans Rhenum incolunt, quibuscum continenter bellum gerunt. Qua de causa Helvetii quoque reliquos Gallos virtute praecedunt, quod fere cotidianis proeliis cum Germanis contendunt, cum aut suis finibus eos prohibent aut ipsi in eorum finibus bellum gerunt.";
+		pause the game;
+		say roman type;
+		now the left hand status line is "[location]";
+		now the right hand status line is "[turn count]".
+	
+	Bank of the Garumna is a room.

--- a/Emily Short/Glulx Text Effects-v6_0_0.i7xd/Materials/Inter/GTEKit/Contents.w
+++ b/Emily Short/Glulx Text Effects-v6_0_0.i7xd/Materials/Inter/GTEKit/Contents.w
@@ -1,0 +1,8 @@
+Title: GTEKit
+Author: Emily Short
+Purpose: Glulx Text Effect kinds.
+Language: Inform 6
+Licence: Creative Commons Atribution 4.0 license.
+Web Syntax Version: 2
+
+Sections

--- a/Emily Short/Glulx Text Effects-v6_0_0.i7xd/Materials/Inter/GTEKit/kinds/Styles.neptune
+++ b/Emily Short/Glulx Text Effects-v6_0_0.i7xd/Materials/Inter/GTEKit/kinds/Styles.neptune
@@ -1,0 +1,45 @@
+new base GLK_STYLE {
+	conforms-to: ENUMERATED_VALUE_TY
+	singular: glulx text style
+	plural: glulx text styles
+
+	specification-text: Glulx text styles are used to mark the purpose of text, and allow authors to customise their appearance.
+
+	instance: all-styles                 = style_All           = -1
+	instance: normal-style               = style_Normal_       = 0
+	instance: italic-style               = style_Emphasized_   = 1
+	instance: fixed-letter-spacing-style = style_Preformatted_ = 2
+	instance: header-style               = style_Header_       = 3
+	instance: bold-style                 = style_Subheader_    = 4
+	instance: alert-style                = style_Alert_        = 5
+	instance: note-style                 = style_Note_         = 6
+	instance: blockquote-style           = style_BlockQuote_   = 7
+	instance: input-style                = style_Input_        = 8
+	instance: special-style-1            = style_User1_        = 9
+	instance: special-style-2            = style_User2_        = 10
+}
+
+new base GLK_FONT_WEIGHT {
+	conforms-to: ENUMERATED_VALUE_TY
+	singular: font weight
+	plural: font weights
+
+	specification-text: A Glk stylehint font weight.
+
+	instance: light-weight   = FONT_WEIGHT_LIGHT   = -1
+	instance: regular-weight = FONT_WEIGHT_REGULAR = 0
+	instance: bold-weight    = FONT_WEIGHT_BOLD    = 1
+}
+
+new base GLK_TEXT_JUSTIFICATION {
+	conforms-to: ENUMERATED_VALUE_TY
+	singular: text justification
+	plural: text justifications
+
+	specification-text: A Glk stylehint text justification.
+
+	instance: left-justified       = stylehint_just_LeftFlush_  = 0
+	instance: left-right-justified = stylehint_just_LeftRight_
+	instance: center-justified     = stylehint_just_Centered_
+	instance: right-justified      = stylehint_just_RightFlush_
+}

--- a/Emily Short/Glulx Text Effects-v6_0_0.i7xd/Materials/Inter/GTEKit/kit_metadata.json
+++ b/Emily Short/Glulx Text Effects-v6_0_0.i7xd/Materials/Inter/GTEKit/kit_metadata.json
@@ -1,0 +1,13 @@
+{
+    "is": {
+        "type": "kit",
+        "title": "GTEKit",
+        "version": "6.0.0"
+    },
+    "compatibility": "32-bit",
+    "kit-details": {
+        "has-priority": 1,
+        "defines-Main": false,
+        "provides-kinds": ["Styles.neptune"]
+    }
+}

--- a/Emily Short/Glulx Text Effects-v6_0_0.i7xd/Source/Glulx Text Effects.i7x
+++ b/Emily Short/Glulx Text Effects-v6_0_0.i7xd/Source/Glulx Text Effects.i7x
@@ -1,0 +1,161 @@
+Version 6.0.0 of Glulx Text Effects (for Glulx only) by Emily Short begins here.
+
+"Gives control over text formatting in Glulx."
+
+[ Version 6 is rewritten for Inform 11, and uses many new features. But for compatibility reasons the naming of things has been, as much as possible, left as it was. This means we have both the US and Commonwealth spelling of color/colour, and we refer to "Glulx" styles rather than Glk styles, as they more accurately should be called. ]
+
+Use authorial modesty.
+
+Chapter - Extra windows
+
+[ We define these windows so that stylehints can be specified for one or both kind of text window. ]
+
+All-windows is a glk window.
+All-buffer-windows is a glk window.
+All-grid-windows is a glk window.
+
+Chapter - The Table of User Styles definition
+
+Table of User Styles
+window (a glk window)	style name (a glulx text style)	background color (an RGB colour)	color (an RGB colour)	first line indentation (a number)	fixed width (a truth state)	font weight (a font weight)	indentation (a number)	italic (a truth state)	justification (a text justification)	relative size (a number)	reversed (a truth state)
+with 1 blank row
+
+Chapter - Default styles
+
+Table of User Styles (continued)
+window	style name	font weight	italic	justification	reversed
+all-grid-windows	all-styles	--	--	--	true
+all-buffer-windows	header-style	--	--	left-justified
+all-buffer-windows	italic-style	regular-weight	true
+
+Chapter - Sorting the Table of User Styles - unindexed
+
+Before starting the virtual machine (this is the sort of the Table of User Styles rule):
+	[ First change empty windows to all buffer windows, and empty style names to all-styles ]
+	repeat through the Table of User Styles:
+		if there is no window entry:
+			now the window entry is all-buffer-windows;
+		if there is no style name entry:
+			now the style name entry is all-styles;
+	[ Now sort with the following algorithm ]
+	sort the Table of User Styles with the table of user styles ranking;
+
+To decide which number is the table ranking of (T - table name) rows (X - a number) and (Y - a number) (this is the table of user styles ranking):
+	let window x be the window in row X of T;
+	let window y be the window in row y of T;
+	[ Sort the all-*-windows rows before window specific rows ]
+	if window x is not window y:
+		if window y is all-windows:
+			decide on 1;
+		if window x is all-windows:
+			decide on -1;
+		if (window y is all-buffer-windows or window y is all-grid-windows) and window x is not all-buffer-windows and window x is not all-grid-windows:
+			decide on 1;
+		if (window x is all-buffer-windows or window x is all-grid-windows) and window y is not all-buffer-windows and window y is not all-grid-windows:
+			decide on -1;
+	[ Sort styles in ascending order, so that all-styles comes first ]
+	decide on (numerical value of style name in row X of T) - (numerical value of style name in row Y of T);
+
+Chapter - Apply the styles - unindexed
+
+[ We're planning ahead here, for the benefit of Flexible Windows. ]
+
+The apply the Glulx Text Effects styles rule is listed instead of the set default stylehints rule in the before starting the virtual machine rules.
+Before starting the virtual machine (this is the apply the Glulx Text Effects styles rule):
+	apply styles for the not a glk window;
+
+To decide which glk window is the not a glk window: (- (nothing) -).
+
+To apply styles for (W - glk window):
+	repeat through the Table of User Styles:
+		let window be the window entry;
+		let window type be a number;
+		if window is all-windows:
+			now window type is 0;
+		otherwise if window is all-buffer-windows:
+			if W is not nothing and the type of W is not text buffer:
+				next;
+			now window type is 3;
+		otherwise if window is all-grid-windows:
+			if W is not nothing and the type of W is not text grid:
+				next;
+			now window type is 4;
+		otherwise:
+			if W is nothing or window is not W:
+				next;
+			if the type of W is text buffer:
+				now window type is 3;
+			otherwise:
+				now window type is 4;
+		if there is a background color entry:
+			apply window type style (style name entry) stylehint 8 of (background color entry);
+		if there is a color entry:
+			apply window type style (style name entry) stylehint 7 of (color entry);
+		if there is a first line indentation entry:
+			apply window type style (style name entry) stylehint 1 of (first line indentation entry);
+		if there is a fixed width entry:
+			let proportional be 1;
+			if the fixed width entry is true:
+				now proportional is 0;
+			apply window type style (style name entry) stylehint 6 of (proportional);
+		if there is a font weight entry:
+			apply window type style (style name entry) stylehint 4 of (font weight entry);
+		if there is a indentation entry:
+			apply window type style (style name entry) stylehint 0 of (indentation entry);
+		if there is a italic entry:
+			apply window type style (style name entry) stylehint 5 of (italic entry);
+		if there is a justification entry:
+			apply window type style (style name entry) stylehint 2 of (justification entry);
+		if there is a relative size entry:
+			apply window type style (style name entry) stylehint 3 of (relative size entry);
+		if there is a reversed entry:
+			apply window type style (style name entry) stylehint 9 of (reversed entry);
+
+To apply (W - a number) style (S - a glulx text style) stylehint (H - a number) of (V - a value):
+	(- GTE_Apply_Stylehint({W}, {S}, {H}, {V}); -).
+
+Include (-
+[ GTE_Apply_Stylehint wintype stylenum hint value i;
+	if (stylenum == style_All) {
+		for (i = 0: i < style_NUMSTYLES : i++) {
+			glk_stylehint_set(wintype, i, hint, value);
+		}
+	}
+	else {
+		glk_stylehint_set(wintype, stylenum, hint, value);
+	}
+];
+-).
+
+Chapter - Additional style phrases
+
+To say alert style:
+	(- glk_set_style(style_Alert); -).
+
+To say blockquote style:
+	(- glk_set_style(style_BlockQuote); -).
+
+To say header style:
+	(- glk_set_style(style_Header); -).
+
+To say input style:
+	(- glk_set_style(style_Input); -).
+
+To say note style:
+	(- glk_set_style(style_Note); -).
+
+To say special-style-1:
+	(- glk_set_style(style_User1); -).
+To say special/custom/user style 1:
+	(- glk_set_style(style_User1); -).
+To say first special/custom/user style:
+	(- glk_set_style(style_User1); -).
+
+To say special-style-2:
+	(- glk_set_style(style_User2); -).
+To say special/custom/user style 2:
+	(- glk_set_style(style_User2); -).
+To say second special/custom/user style:
+	(- glk_set_style(style_User2); -).
+
+Glulx Text Effects ends here.

--- a/Emily Short/Glulx Text Effects-v6_0_0.i7xd/Source/Glulx Text Effects.i7x
+++ b/Emily Short/Glulx Text Effects-v6_0_0.i7xd/Source/Glulx Text Effects.i7x
@@ -73,17 +73,17 @@ To apply styles for (W - glk window):
 		if window is all-windows:
 			now window type is 0;
 		otherwise if window is all-buffer-windows:
-			if W is not nothing and the type of W is not text buffer:
+			if W is not nothing and the window type of W is not text buffer window type:
 				next;
 			now window type is 3;
 		otherwise if window is all-grid-windows:
-			if W is not nothing and the type of W is not text grid:
+			if W is not nothing and the window type of W is not text grid window type:
 				next;
 			now window type is 4;
 		otherwise:
 			if W is nothing or window is not W:
 				next;
-			if the type of W is text buffer:
+			if the window type of W is text buffer window type:
 				now window type is 3;
 			otherwise:
 				now window type is 4;

--- a/Emily Short/Glulx Text Effects-v6_0_0.i7xd/extension_metadata.json
+++ b/Emily Short/Glulx Text Effects-v6_0_0.i7xd/extension_metadata.json
@@ -1,0 +1,17 @@
+{
+    "is": {
+        "type": "extension",
+        "title": "Glulx Text Effects",
+        "author": "Emily Short",
+        "version": "6.0.0"
+    },
+    "compatibility": "Glulx only",
+    "needs": [
+        {
+            "need": {
+                "type": "kit",
+                "title": "GTEKit"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
I've update GTE for Inform 11 - my first time making a directory extension.

I just remembered that I want to try making the window column be a description. Ah, but you can't store a description in a table. It would be neat to be able to do that, and come up with more advanced filters for the table (I was mainly thinking of applying styles to a sub-kind of glk window), but if descriptions aren't possible it would be much more messy. Also it would be pretty much impossible to sort the table. So not actually a good idea.