### PR TITLE
Update .gitignore to exclude .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 releases
 *~
+.DS_Store


### PR DESCRIPTION
There's one of those annoying Mac system files, getting in the repositories again. This should hopefully fix things.