### PR TITLE
Trying this again - pulling Dynamic Tables and Dynamic Objects extensions  (+ 2 minor filename changes) to the 11.0 branch

### DIFF
--- a/Emily Short/Complex Listing-v9_0_1.i7xd/Documentation/Examples/WhichOfTheseThingsIsNotLikeTheOthers.txt
+++ b/Emily Short/Complex Listing-v9_0_1.i7xd/Documentation/Examples/WhichOfTheseThingsIsNotLikeTheOthers.txt
@@ -1,4 +1,4 @@
-Example: * Which of These Things Is Not Like the Others?
+Example: * Which of These Things Is Not Like the Others
 Description: Arranging items in room descriptions so that the most unusual objects are always at the back of the list.
 
 A common descriptive strategy in listing numerous objects is to save the most astonishing or interesting items for last. In this example, we arrange it so that the most peculiar items in a room are always included at the end of the list, no matter in what order they have been taken or dropped.

--- a/Tara McGrew/Dynamic Objects-v10_0_0.i7xd/Documentation/Documentation.md
+++ b/Tara McGrew/Dynamic Objects-v10_0_0.i7xd/Documentation/Documentation.md
@@ -1,0 +1,74 @@
+Chapter: Basic cloning
+
+This extension allows new objects to be created by cloning existing objects. Once we've defined a suitable prototype object, we can refer to "a new object cloned from" it, like so:
+
+	let the copy be a new object cloned from the prototype;
+
+That line will create the new object and assign it to the variable called "copy". The copy will be the same kind as the prototype, and have all the same property values.
+
+By default, the new object will not be participating in any of the relationships of the prototype object. To clone the relationships as well, use the "preserving relations" option:
+
+	let the copy be a new object cloned from the prototype, preserving relations;
+
+Note that even with this option, one-to-various (or various-to-one) relationships are only preserved when the cloned object is on the "various" side, and one-to-one relationships are never preserved.
+
+If memory runs out and the new object cannot be created, the phrase will return "nothing".
+
+Chapter: The "cloning a new object from" activity
+
+The cloning process is implemented as an activity called "cloning a new object from". We can write "before cloning a new object from" rules to intervene before the object is cloned, and in those rules we can refer to "preserving relations" as a truth state which is true if the process is going to preserve object relationships.
+
+We can also write "after cloning a new object from" rules to intervene after the object is cloned, and in those we can also refer to the clone as "the new object":
+
+	A thing has a number called the clone generation.
+	
+	After cloning a new object from something:
+		increase the clone generation of the new object by 1.
+
+In this example, we change the behavior of "preserving relations" so that when the original object relates to itself, the clone also relates to itself (and not to the original object):
+
+	Love relates various people to various people. The verb to love (he loves, they love, he is loving, he is loved) implies the love relation.
+	
+	After cloning a new object from a person (called the original):
+		if preserving relations is true and the original loves the original:
+			now the new object does not love the original;
+			now the original does not love the new object;
+			now the new object loves the new object.
+
+Section: Handling block value properties
+
+When cloning objects that have properties containing block values (indexed text, stored actions, lists, or dynamic relations), we must indicate which properties those are so the extension can copy their values correctly; otherwise we may encounter unexpected behavior or runtime problem messages if the property values are changed. Use the "fix the cloned _ property" phrase in an "after cloning a new object from" rule:
+
+	A person has a list of numbers called the favorite numbers.
+	
+	After cloning a new object from a person:
+		fix the cloned favorite numbers property.
+
+Chapter: Caveats
+
+If we plan to clone any rooms or doors, we must disable fast route-finding (which is enabled by default on Glulx):
+
+	Use slow route-finding.
+
+Chapter: Change log
+
+Version 2 uses Dynamic Tables (by the same author) to avoid replacing the standard locale description rules, and allows cloned objects to participate in all relations.
+
+Version 3 works with Inform 7 version 5U92.
+
+Version 4 fixes a bug with relations.
+
+Version 5 works with Inform 7 version 6E59. It also adds the "cloning a new object from" activity and the "fix the cloned _ property" phrase to allow block-type properties to be cloned correctly. It also changes the behavior (and specification) of "preserving relations" with regard to one-to-one relations: now they are never preserved, since that would result in removing the original object from the relation.
+
+Version 6 works with Inform 7 version 6G60.
+
+Version 7 fixes another bug with relations and a bug that prevented the "new object cloned from" phrase from being used in certain contexts.
+
+Version 8 works with (and requires) Inform 7 version 6L02.
+
+Version 8/220204 patch to DO_UnlinkProp in a stab toward 6M62 compatibility
+
+Version 9 works with Inform 7 version 10.1.2.
+
+Version 10 works with Inform 7 version 10.2 (though note, with version 10.2 being in active development, this may change - the extension was successfully tested with a build of the current master branch as of March 24, 2026 at 22:24 GMT) Note that version 10 is NOT backward compatible with Inform 10.1.x when compiled for Glulx.
+

--- a/Tara McGrew/Dynamic Objects-v10_0_0.i7xd/Documentation/Documentation.md
+++ b/Tara McGrew/Dynamic Objects-v10_0_0.i7xd/Documentation/Documentation.md
@@ -37,7 +37,7 @@ In this example, we change the behavior of "preserving relations" so that when t
 
 Section: Handling block value properties
 
-When cloning objects that have properties containing block values (indexed text, stored actions, lists, or dynamic relations), we must indicate which properties those are so the extension can copy their values correctly; otherwise we may encounter unexpected behavior or runtime problem messages if the property values are changed. Use the "fix the cloned _ property" phrase in an "after cloning a new object from" rule:
+When cloning objects that have properties containing block values (text*, stored actions, lists, or dynamic relations), we must indicate which properties those are so the extension can copy their values correctly; otherwise we may encounter unexpected behavior or runtime problem messages if the property values are changed. Use the "fix the cloned _ property" phrase in an "after cloning a new object from" rule:
 
 	A person has a list of numbers called the favorite numbers.
 	
@@ -49,6 +49,40 @@ Chapter: Caveats
 If we plan to clone any rooms or doors, we must disable fast route-finding (which is enabled by default on Glulx):
 
 	Use slow route-finding.
+
+Chapter: Known Issues
+
+*Fixing the cloned ... property, for "block" value properties, which now includes ALL text properties:
+
+Those familiar with older versions of Inform (prior to the Inform 7 6L02 release) likely recall the need to differentiate between dynamic "indexed text" and static "text" types. That distinction no longer exists (a good thing), but that means ALL text is now (potentially) dynamic. Therefore, it's necessary to "fix the cloned ... property" for EVERY TEXT property of any object we clone. Failure to do so will results in cloned objects pointing to the same exact property value as the original object, so that changing that value in any one of the objects in question changes it FOR ALL of the objects.  
+
+This means that, while previously, having to write "after cloning a new object" rules to fix block properties was likely to be rare, it's an absolute necessity now. 
+
+For example, the default "thing" kind alone features the following text properties: description, initial appearance, printed name, printed plural name, indefinite article, list grouping key.
+
+At the moment, this extension does nothing to address this. Rather, at a minimum, if you intend to clone any "things" (or object kinds derived from the "thing" kind) you MUST write an "After cloning a new object from a thing" rule, as well as a similar rule for each derived kind that adds one or more text or other "block" type  properties of its own. 
+
+If there were a straightforward way in either Inform 7 or Inform 6 to iterate over all the properties of an object (or kind) at runtime, this extension could attempt to automatically "fix" any cloned "block"  properties automatically. Unfortunately, there seems to be no straightforward way to accomplish that, and it's beyond the scope of this extension to attempt to resolve that particular problem. 
+
+**Counting objects of a kind 
+
+The standard way to determine how many objects match any sort of description in Inform is just to use
+
+	the number of <description of objects>
+
+This currently works fine with Dynamic Objects *unless the description of objects is just the name of a kind*. Where "widget" is a kind, the expression ...
+
+	the number of widgets
+
+returns ONLY the number of statically defined widgets. If any dynamic objects of the widget kind are created, they are not inlcuded in the count. 
+
+As time permits, I may try to track down a resolution for this. In the meantime, the following "hack" works:
+
+	Definition: A thing is total if: decide yes. 
+
+	let N be the number of total widgets; [Returns a count of ALL widgets, including any that were dynamically created]
+
+I expect this forces Inform to walk through the list of widgets, as will be the case with most descriptions of objects, testing the (in this case always trivially true) condition for each one. Whereas the former almost certain relies either on querying an I6 variable (in which case a simple enough fix should be possible) or else a compile-time constant (in which case any resolution is probably beyond the scope of this extension). 
 
 Chapter: Change log
 

--- a/Tara McGrew/Dynamic Objects-v10_0_0.i7xd/Documentation/Examples/TheCubbinsEffect.txt
+++ b/Tara McGrew/Dynamic Objects-v10_0_0.i7xd/Documentation/Examples/TheCubbinsEffect.txt
@@ -1,0 +1,36 @@
+Example: * The Cubbins Effect
+Description: Creating a new hat every time the player removes the one he's wearing.
+
+	{*}"The Cubbins Effect" by Geodor Theisel
+	
+	Include Dynamic Objects by Tara McGrew.
+	
+	King Derwin's Court is a room. "You have been summoned here for the crime of failing to remove your hat in the king's presence."
+	
+	A hat is a kind of thing.
+	
+	A hat style is a kind of value. The hat styles are red, blue, green, yellow, white, black, brown, zebra-striped, tall, pointy, short, gray, pink, fuzzy, rainbow-colored, and feathered.
+	
+	A hat has a hat style. Before printing the name of a hat, say "[hat style] ". Understand the hat style property as describing a hat.
+	
+	The player wears a hat which is red.
+	
+	Instead of taking off a hat which is worn by the player:
+		now the noun is in the location;
+		if 500 hats are in the location:
+			say "You remove [the noun] and drop it. It seems that was the last one!";
+			end the story finally saying "You have won";
+		otherwise:
+			let the new hat be a new object cloned from the noun;
+			now the player is wearing the new hat;
+			say "You remove [the noun] and drop it, only to find another hat upon your head -- a [hat style of the new hat] one."
+
+	After cloning a new object from a hat (called the original hat):
+		while the hat style of the new object is the hat style of the original hat:
+			now the hat style of the new object is a random hat style.
+	
+	Rule for printing a number of hats (called the particular headwear):
+		say "[listing group size in words] [hat style of the particular headwear] hats".
+	
+	Test me with "remove hat / remove hat / remove hat / i / look".
+

--- a/Tara McGrew/Dynamic Objects-v10_0_0.i7xd/Source/Dynamic Objects.i7x
+++ b/Tara McGrew/Dynamic Objects-v10_0_0.i7xd/Source/Dynamic Objects.i7x
@@ -1,0 +1,562 @@
+Version 10.0.0 of Dynamic Objects (for Glulx only) by Tara McGrew begins here.
+
+"Provides the ability to create new objects during game play."
+
+"ported to Inform 10.1.2 by Alwinfy / ported to 10.2.x (in development) by Taryn Michelle"
+
+Include Dynamic Tables by Tara McGrew.
+
+Chapter 1 - Cloning objects
+
+Include (- Array do_temp_array --> 3; -).
+
+Cloning a new object from something is an activity on objects.
+
+The cloning a new object from activity has an object called the new object. [This has to be first! See below.]
+The cloning a new object from activity has a truth state called preserving relations.
+
+Section 1 - 'a new object cloned from'
+
+To decide which object is a new object cloned from (prev - an object), preserving relations: (- DO_CloneObject({prev}, {phrase options}) -).
+
+To decide if I6 wants preserving relations: (- do_temp_array-->0 -).
+
+First before cloning a new object from (this is the dynamic objects setting activity variables rule):
+	if I6 wants preserving relations:
+		now preserving relations is true.
+
+Include (-
+
+! FIXME: N_ATTR_BYTES is a drop-in alias for NUM_ATTR_BYTES.
+! This is, according to Inform 6 design, mutable as a compiler switch,
+! but currently Inform 7 uses a value of 7.
+! If this ever changes, things will very certainly break catastrophically--
+! if that happens, please update this value!
+Constant N_ATTR_BYTES = 7;
+
+! FIXME: See above; there's an I6 value, GLULX_OBJECT_EXT_BYTES,
+! which appends some extra data (bytes) to the end of a Glulx object.
+! Again, this is unused by I7, but it's what the zero here should change to
+! if that fact is ever invalidated.
+Constant OBJECT_STRUCT_SIZE = N_ATTR_BYTES + 25 + 0;
+
+[ DO_CloneObject src opts  rv props i;
+	! need to have something to copy from
+	if ((src == 0) || (src->0 ~= $70)) rfalse;
+
+	do_temp_array-->0 = (opts ~= 0);	! will be copied to "preserving relations"
+	BeginActivity((+ cloning a new object from activity +), src);
+
+	if (ForActivity((+ cloning a new object from activity +), src) == false) {
+		! copy property table (this also allocates the fixed-size object structure at the beginning)
+		rv = DO_CloneProperties(src);
+		if (~~rv) { AbandonActivity((+ cloning a new object from activity +), src); rfalse; }
+		props = rv + OBJECT_STRUCT_SIZE;
+
+		! initialize object
+		rv->0 = $70;						! type ID
+		for ( i=1: i<=N_ATTR_BYTES: i++ ) rv->i = src->i;	! attributes
+		i = (1 + N_ATTR_BYTES) / 4;
+		rv-->i = 0;						! next object link
+		rv-->(i+1) = src-->(i+1);					! hardware name
+		rv-->(i+2) = props;					! property table
+		rv-->(i+3) = 0;						! parent
+		rv-->(i+4) = 0;						! sibling
+		rv-->(i+5) = 0;						! child
+
+		! use the vanilla copy fn
+		! Copy__Primitive(rv, src);
+
+		! insert object into Inform's linked lists
+		DO_LinkObject(src, rv);
+
+		! update relation structures and maintain invariants for symmetric relations
+		DO_FixRelations(src, rv, opts);
+	}
+	
+	! we can't refer to the activity variable "new object" from here, so we rely on knowing that it's the first variable in this activity (see above)
+	MStack-->MstVO(10000 + (+ cloning a new object from activity +), 0) = rv;
+	
+	EndActivity((+ cloning a new object from activity +), src);
+	return rv;
+];
+
+[ DO_CountThings cnt ptr;
+	! this assumes that Inform places selfobj as the first thing in the chain
+	ptr = selfobj;
+	cnt = 0;
+	while ((ptr + 1 + N_ATTR_BYTES)-->0) {
+		ptr = (ptr + 1 + N_ATTR_BYTES)-->0;
+		cnt = cnt + 1;
+	}
+	return cnt;
+]
+-).
+
+[ HACK: We need to add this because Inform 7 actually inlines the number of objects
+created at runtime, so instead we have to chase down the number of things ourselves. ]
+[ // TM 2026-28-03 - No need to recount every single time though. ]
+DO_current_thing_count is a number that varies. 
+To decide what number is the computed number of things: (- DO_CountThings() -). [Should only ever need to call this once]
+
+[Use of the "incremented" phrase option is meant to be invoked internally, and ONLY from the "dynamic objects belt loosening rule".
+It's used to keep an accurate running total and thus avoid having to recount all objects each time something is cloned. The optimization likely only matters when we have quite a 
+LOT of objects, but then, a project that means to make use of dynamic object creation might well do just that.]
+To decide what number is the current number of things, incremented:
+	if DO_current_thing_count <= 0:
+		now DO_current_thing_count is the computed number of things;
+	otherwise if incremented: [ // Note that if we just counted everything, we skip the increment as the added object will already be accounted for]
+		increment DO_current_thing_count;
+	decide on DO_current_thing_count.
+
+First after cloning a new object from a thing (this is the dynamic objects belt loosening rule):
+	let NT be the current number of things, incremented;
+	[say "Now there are a total of [NT] things altogether in the game world.";]
+	if the number of rows in the Table of Locale Priorities is less than NT:
+		change the Table of Locale Priorities to have NT + 16 rows.
+
+Section 2 - Cloning the property table
+
+Include (-
+[ DO_CloneProperties src  orig size i rv;
+
+	! find source object's property table
+	src = (src + 9 + N_ATTR_BYTES)-->0;
+	orig = src;
+
+	! measure size of table
+	size = 4;
+	i = src-->0;
+	src = src + 4;
+	while (i > 0) {
+		size = size + 10 + ((src-->0 & $FFFF) * WORDSIZE);
+		src = src + 10;
+		i--;
+	}
+
+	! obtain memory for new table
+	rv = DT_Alloc(size + OBJECT_STRUCT_SIZE);
+	! print "*** Allocated ", size + OBJECT_STRUCT_SIZE, " bytes at addr ", rv, ". ***^";
+	if (~~rv) rfalse;
+	rv = rv + OBJECT_STRUCT_SIZE;
+
+	! copy it
+	DT_CopyBytes(size, orig, rv);
+
+	! adjust property data pointers
+	i = rv-->0;
+	src = rv + 4;
+	while (i > 0) {
+		src-->1 = src-->1 - orig + rv;
+		src = src + 10;
+		i--;
+	}
+
+	return rv - OBJECT_STRUCT_SIZE;
+];
+-).
+
+Section 3 - Linking the new object into the world model
+
+[Inform 6 implements objectloop on Glulx by putting all objects in a linked list. We need to add the new object to this linked list so it can be found by objectloop.
+
+Additionally, Inform 7 optimizes kind-based objectloops by adding properties containing a linked list for each kind: all things are linked together in one list, all containers are linked together in another list, and so on. Each kind has its own link property. There's no direct way to look up the property from the kind, but we can take advantage of the fact that they have similar names which are both available at runtime: a kind whose I6 name is K2_thing uses the link property K2_thing_Next.]
+
+Include (-
+
+! NOTE: This is a hack, as (obj).(prop) notations differ in I6 and I7.
+! The way Inform 7 stores properties is as a pointer to 2-word array,
+! where the first word is actually a type tag specifying whether the I7 property
+! is in fact an I6 property or just an I6 attribute.
+
+! Thus to make the compiler play nice, we instead store the prop in proptemp-->1,
+! then say (obj).(do_proptemp).
+Array do_proptemp --> 2;
+
+[ DO_LinkObject src obj  i last prop nk;
+	! add obj to the linked list of all objects
+	last = 0;
+	for (i=Class: i: i=(i + 1 + N_ATTR_BYTES)-->0)
+		last = i;
+	if (last)
+		(last + 1 + N_ATTR_BYTES)-->0 = obj;
+	! last = (src + 1 + N_ATTR_BYTES)-->0;
+	! (obj + 1 + N_ATTR_BYTES)-->0 = last;
+	! (src + 1 + N_ATTR_BYTES)-->0 = obj;
+
+	! add obj to the linked lists for each kind it's a member of
+	nk = obj.KD_Count;
+	while (nk > 0) {
+		i = nk*2;
+		prop = DO_FindLinkProp(obj, KindHierarchy-->i);
+		nk = KindHierarchy-->(i+1);
+		if (prop) {
+			do_proptemp-->1 = prop;
+			last = src;
+			while (last.do_proptemp) {
+				last = last.do_proptemp;
+			}
+			last.do_proptemp = obj;
+			obj.do_proptemp = 0;
+		} else {
+			! Arriving here means the object just created will not have been added to the linked list of objects of the shown class
+			! The object still exists, but it won't be found by many of Inform's built-in mechanisms. The most immediately obvious consequence is that it won't 
+			! show up in default room descriptions, inventory lists, or the like. 
+			print "*** Failed to find link property for ", (object) KindHierarchy-->i, " ***^";
+		}
+	}
+];
+
+Constant DO_PROPBUF_LEN 256;
+Array do_propbuf1 buffer DO_PROPBUF_LEN;	! the kind name, e.g. "K2_thing"
+Array do_propbuf2 buffer DO_PROPBUF_LEN;	! the property name, e.g. "K2_thing_Next"
+
+[ DO_FindLinkProp obj kind pt i prop;
+	! get kind name
+	VM_PrintToBuffer(do_propbuf1, DO_PROPBUF_LEN, DO_PrintObject, kind);
+
+	! find obj's property table
+	pt = (obj + 9 + N_ATTR_BYTES)-->0;
+	! print "*** Vtable for linking found at ", pt, ". ***^";
+
+	! check each property
+	i = pt-->0;
+	pt = pt + 4;
+	while (i > 0) {
+		prop = ((pt-->0) / $10000) & $FFFF;
+		!print "*** NOTE: property ", (property) prop, " has size ", (pt-->0 & $ffff), " **^";
+		if (((pt-->2) / $10000) & $1) {
+			print "** WARN: property ", (property) prop, " declared private **^";
+		}
+		VM_PrintToBuffer(do_propbuf2, DO_PROPBUF_LEN, DO_PrintProperty, prop); ! will print result of DO_PrintProperty (prop)
+		if (DO_PropBufsMatch()) {
+			!print "*** NOTE: Found property so this SHOULD work ***^";
+			! sanity check: ensure this property is indeed a pointer-to-object
+			i = pt-->1-->0;
+			if (i ~= 0 && i->0 ~= $70) {
+				print "*** ERROR: found LL prop ", (property) prop, " with bad ptr ", i->0, " ***^";
+				rfalse;
+			}
+			return prop;
+		}
+		pt = pt + 10;
+		i--;
+	}
+
+	rfalse;
+];
+
+[ DO_PrintObject x; print (object) x; ];
+[ DO_PrintProperty x; print (property) x; ];
+
+[ DO_PropBufsMatch  len p1 p2 i;
+	! do_propbuf1 contains the kind name (e.g. K2_Thing)
+	! do_propbuf2 contains the property name to check. 
+	!print "*** Comparing the following (p1 / p2) ^";
+	!VM_PrintBuffer( do_propbuf1 );
+	!print " / ";
+	!VM_PrintBuffer( do_propbuf2 );
+	!print "^";
+	len = do_propbuf1-->0;
+	! Don't bother if property name is the wrong length and so can't possibly be "<kindname>_Next"
+	if (do_propbuf2-->0 ~= len + 5) rfalse;
+	
+	! In 10.2, compiling for glulx defaults to using 4-byte character codes (DICT_CHAR_SIZE = 4). 
+	! This requires a different approach to testing the contents of the buffer array, since we need to access character codes a word (4 bytes) at a time. 
+	
+	! *** From this point the necessary code differs based on DICT_CHAR_SIZE, which we can't presently test at runtime. This is the correct code for 32-bit Glulx
+	len = len + 1; ! Note the offset of 1 rather than WORDSIZE (because we'll be reading WORDS and not BYTES)
+	for (i=1:i<len:++i) {
+		! Note also the use of the --> operator as opposed to -> to access characters a 32-bit word (4 bytes) at a time
+		if (do_propbuf1-->i ~= do_propbuf2-->i) rfalse; 
+	}
+	! We passed that check, now just test whether the last five characters of the property name are "_Next"
+	if (do_propbuf2-->i++ ~= '_') rfalse;
+	if (do_propbuf2-->i++ ~= 'N') rfalse;
+	if (do_propbuf2-->i++ ~= 'e') rfalse;
+	if (do_propbuf2-->i++ ~= 'x') rfalse;
+	if (do_propbuf2-->i++ ~= 't') rfalse;
+	rtrue;
+] -).
+
+[ The below version of the DO_PropBufsMatch function works with DICT_CHAR_SIZE = 1, which is the Glulx haracter format Inform 10.1 builds evidently used by default. As there is currently no easy way to detect the character size at runtime, we can't just seamlessly switch between them. Keeping the alternate format version here, commented out, in case that proves to be useful in the future. ]
+[ Include (-
+[ DO_PropBufsMatch  len p1 p2 i;
+	! do_propbuf1 contains the kind name (e.g. K2_Thing)
+	! do_propbuf2 contains the property name to check. 
+	!print "*** Comparing the following (p1 / p2) ^";
+	!VM_PrintBuffer( do_propbuf1 );
+	!print " / ";
+	!VM_PrintBuffer( do_propbuf2 );
+	!print "^";
+	len = do_propbuf1-->0;
+	! Don't bother if property name is the wrong length and so can't possibly be "<kindname>_Next"
+	if (do_propbuf2-->0 ~= len + 5) rfalse;
+	
+	! In 10.2, compiling for glulx defaults to using 4-byte character codes (DICT_CHAR_SIZE = 4). 
+	! This requires a different approach to testing the contents of the buffer array. en using the -> operator, we end up accessing 4-byte character codes a byte at a time. 
+	! For backward-compatability, we need to test this 
+	
+	! *** From this point the necessary code differs based on DICT_CHAR_SIZE, which we can't presently test at runtime. This is the single-byte character size version.
+	len = len + WORDSIZE; ! For Z8 we're going to be reading BYTES, so increment by WORDSIZE to skip past length, then use the -> operator to read a byte at a time
+	for (i=WORDSIZE:i<len:++i) {
+		if (do_propbuf1->i ~= do_propbuf2->i) rfalse; 
+	}
+	! We passed that check, now just check that the last fiver characters of the property name are "_Next"
+	if (do_propbuf2->i++ ~= '_') rfalse;
+	if (do_propbuf2->i++ ~= 'N') rfalse;
+	if (do_propbuf2->i++ ~= 'e') rfalse;
+	if (do_propbuf2->i++ ~= 'x') rfalse;
+	if (do_propbuf2->i++ ~= 't') rfalse;
+	rtrue;
+]; -).]
+
+Section 4 - Restoring the object's ability to relate, and possibly its relationships
+
+[Static various-to-various relations are stored as a rectangular bitmap, whose size is determined by the compiler based on the number of objects in the relation's domains. After cloning an object, we must resize all of the bitmaps for relations which apply to the new object.]
+
+Include (-
+[ DO_FixRelations src obj preserve  i storage;
+	do_temp_array-->0 = src;
+	do_temp_array-->1 = obj;
+	do_temp_array-->2 = preserve;
+	IterateRelations(DO_FixEachRelation);
+];
+
+[ DO_FixEachRelation rel  src obj preserve i k1 k2 list storage handler valency;
+	! skip read-only relations
+	if (~~(rel-->RR_PERMISSIONS & RELS_ASSERT_TRUE)) return;
+	
+	k1 = KindBaseTerm(rel-->RR_KIND, 0);
+	k2 = KindBaseTerm(rel-->RR_KIND, 1);
+	
+	if (DO_RelationKindApplies(k1, obj) || DO_RelationKindApplies(k2, obj)) {
+		src = do_temp_array-->0;
+		obj = do_temp_array-->1;
+		preserve = do_temp_array-->2;
+		
+		valency = RELATION_TY_GetValency(rel);
+		
+		if (DO_IsDynamicRelation(rel)) {
+			! dynamic relation: the relation structure is fine, just add the new object to it if preserving
+			if (preserve && valency ~= RRVAL_O_TO_O or RRVAL_SYM_O_TO_O) {
+				list = LIST_OF_TY_Create(k2);
+				handler = rel-->RR_HANDLER;
+				if (valency ~= RRVAL_O_TO_V && DO_RelationKindApplies(k1, obj)) {
+					handler(rel, RELS_LOOKUP_ALL_Y, src, list);
+					for ( i=LIST_OF_TY_GetLength(list): i>0: i-- )
+						handler(rel, RELS_ASSERT_TRUE, obj, LIST_OF_TY_GetItem(list, i));
+				}
+				if (valency ~= RRVAL_V_TO_O && DO_RelationKindApplies(k2, obj)) {
+					handler(rel, RELS_LOOKUP_ALL_X, src, list);
+					for ( i=LIST_OF_TY_GetLength(list): i>0: i-- )
+						handler(rel, RELS_ASSERT_TRUE, LIST_OF_TY_GetItem(list, i), obj);
+				}
+				FlexFree(list);
+			}
+		} else if ((storage = rel-->RR_STORAGE) ~= 0) {
+			! static relation: we may need to resize the storage array (for V-to-V) or clear properties (for others, when not preserving)
+			switch (valency) {
+				RRVAL_O_TO_V, RRVAL_V_TO_O: if (~~preserve) DO_ClearOtoX(obj, storage);
+				RRVAL_O_TO_O, RRVAL_SYM_O_TO_O: DO_ClearOtoX(obj, storage);
+				RRVAL_V_TO_V: rel-->RR_STORAGE = DO_AddVtoV(obj, storage, preserve, src, 0);
+				RRVAL_SYM_V_TO_V: rel-->RR_STORAGE = DO_AddVtoV(obj, storage, preserve, src, 1);
+				RRVAL_EQUIV: if (~~preserve) DO_ClearEquiv(obj, storage);
+			}
+		}
+	}
+];
+
+[ DO_IsDynamicRelation rel;
+	! static relations start with REL_BLOCK_HEADER (which includes the BLK_FLAG_RESIDENT bit)
+	if (rel-->0 == REL_BLOCK_HEADER) rfalse;
+	rtrue;
+];
+
+[ DO_RelationKindApplies rk obj;
+	! relations between any kinds of objects are (as of 6E59) stored as relations of OBJECT_TY,
+	! but maybe that will change in the future
+	if (rk == OBJECT_TY) rtrue;
+	rfalse;
+];
+
+[ DO_ClearOtoX obj prop;
+	if (obj provides prop) obj.prop = nothing;
+];
+
+[ DO_ClearEquiv obj prop  last i;
+	if (obj provides prop) {
+		last = 0;
+		objectloop (i provides prop)
+			if (i.prop > last) last = i.prop;
+		obj.prop = last + 1;
+	}
+];
+
+Constant VTOVS_HDR_WORDS = 8;
+
+[ DO_AddVtoV obj bitmap preserve src sym  lp rp nbmp i m l r n oli ori;
+	lp = bitmap-->VTOVS_LEFT_INDEX_PROP;
+	rp = bitmap-->VTOVS_RIGHT_INDEX_PROP;
+	if (obj provides lp) {
+		if (obj provides rp) m = 3;		! both
+		else m = 1;			! left only
+	} else {
+		if (obj provides rp) m = 2;		! right only
+		else return bitmap;
+	}
+
+	! calculate new domain size
+	l = bitmap-->VTOVS_LEFT_DOMAIN_SIZE;
+	if (m == 1 or 3) { oli = obj.lp; obj.lp = l; l++; }
+	r = bitmap-->VTOVS_RIGHT_DOMAIN_SIZE;
+	if (m == 2 or 3) { ori = obj.rp; obj.rp = r; r++; }
+	n = l * r;
+
+	! allocate memory for new bitmap
+	! 1 word for static bitmap pointer + 8 word v2v header + 1 word per 16 entries in the bitmap
+	nbmp = DT_Alloc((1 + VTOVS_HDR_WORDS + ((n+15)/16)) * WORDSIZE);
+	if (~~nbmp) { print "*** No memory to resize V2V relation ***^"; rfalse; }
+
+	! point from the dynamic bitmap to the static bitmap
+	if (bitmap >= Flex_Heap) nbmp-->0 = bitmap-->(-1); else nbmp-->0 = bitmap;
+
+	! point from the static bitmap to the dynamic bitmap
+	!(nbmp-->0)-->0 = -1;
+	!(nbmp-->0)-->1 = nbmp + WORDSIZE;
+
+	! fill in V2V header
+	nbmp = nbmp + WORDSIZE;
+	nbmp-->VTOVS_LEFT_INDEX_PROP = lp;
+	nbmp-->VTOVS_RIGHT_INDEX_PROP = rp;
+	nbmp-->VTOVS_LEFT_DOMAIN_SIZE = l;
+	nbmp-->VTOVS_RIGHT_DOMAIN_SIZE = r;
+	nbmp-->VTOVS_LEFT_PRINTING_ROUTINE = bitmap-->VTOVS_LEFT_PRINTING_ROUTINE;
+	nbmp-->VTOVS_RIGHT_PRINTING_ROUTINE = bitmap-->VTOVS_RIGHT_PRINTING_ROUTINE;
+	nbmp-->VTOVS_CACHE_BROKEN = 1;
+	nbmp-->VTOVS_CACHE = 0;
+
+	! expand the bits
+	l = bitmap-->VTOVS_LEFT_DOMAIN_SIZE;
+	r = bitmap-->VTOVS_RIGHT_DOMAIN_SIZE;
+	if (m == 2 or 3) {
+		! need to insert bits for a new column
+		DO_InsertBits(bitmap + VTOVS_HDR_WORDS*WORDSIZE, l * r, r, nbmp + VTOVS_HDR_WORDS*WORDSIZE);
+	} else {
+		! just copy
+		for (i=(l*r + 15)/16: i>0: --i)
+			nbmp-->(VTOVS_HDR_WORDS+i) = bitmap-->(VTOVS_HDR_WORDS+i);
+	}
+
+	! preserve relations if needed
+	if (preserve) {
+		if (m == 1 or 3)
+			objectloop (i provides rp)
+				if (DO_Relation_TestVtoV_Raw(src, bitmap, i, sym))
+					DO_Relation_NowVtoV_Raw(obj, nbmp, i, sym);
+
+		if ((~~sym) && m == 2 or 3)
+			objectloop (i provides lp)
+				if (DO_Relation_TestVtoV_Raw(i, bitmap, src, sym))
+					DO_Relation_NowVtoV_Raw(i, nbmp, obj, sym);
+	}
+
+	! deallocate old bitmap if necessary
+	if (bitmap >= Flex_Heap) DT_Free(bitmap - WORDSIZE);
+
+	return nbmp;
+];
+
+! expands 'nbits' bits from src to dest, inserting a zero bit every
+! 'interval' bits and using only the lower 16 bits of each word.
+! the number of words used for dest is (nbits+(nbits/interval)+15)/16.
+[ DO_InsertBits src nbits interval dest  sw sb dw db i si f;
+	sw = 0; sb = 1; dw = 0; db = 1;
+	nbits = nbits + (nbits / interval);
+	f = 0; si = 0;
+	for (i=0: i<nbits: i++) {
+		if (db == 1) dest-->dw = 0;
+		if (f) {
+			f = 0;
+		} else {
+			if (src-->sw & sb) dest-->dw = dest-->dw | db;
+			sb = sb * 2;
+			if (sb == $10000) { sw++; sb = 1; }
+			si++;
+			if (si == interval) { f = 1; si = 0; }
+		}
+		db = db * 2;
+		if (db == $10000) { dw++; db = 1; }
+	}
+];
+
+! "raw" versions of a couple functions from Relations.i6t, to operate directly on the V2V bitmap
+[ DO_Relation_NowVtoV_Raw obj1 vtov_structure obj2 sym pr pr2 i1 i2;
+	if (sym && (obj2 ~= obj1)) { DO_Relation_NowVtoV_Raw(obj2, vtov_structure, obj1, false); }
+	pr = vtov_structure-->VTOVS_LEFT_INDEX_PROP;
+	pr2 = vtov_structure-->VTOVS_RIGHT_INDEX_PROP;
+	vtov_structure-->VTOVS_CACHE_BROKEN = true; ! Mark any cache as broken
+	if (pr) {
+		! if ((obj1 ofclass Object) && (obj1 provides pr)) i1 = obj1.pr;
+		! else return RunTimeProblem(RTP_IMPREL, obj1, relation);
+		i1 = obj1.pr;
+	} else i1 = obj1-1;
+	if (pr2) {
+		! if ((obj2 ofclass Object) && (obj2 provides pr2)) i2 = obj2.pr2;
+		! else return RunTimeProblem(RTP_IMPREL, obj2, relation);
+		i2 = obj2.pr2;
+	} else i2 = obj2-1;
+	pr = i1*(vtov_structure-->VTOVS_RIGHT_DOMAIN_SIZE) + i2;
+	i1 = IncreasingPowersOfTwo_TB-->(pr%16);
+	pr = pr/16 + 8;
+	vtov_structure-->pr = (vtov_structure-->pr) | i1;
+];
+
+[ DO_Relation_TestVtoV_Raw obj1 vtov_structure obj2 sym pr pr2 i1 i2;
+	pr = vtov_structure-->VTOVS_LEFT_INDEX_PROP;
+	pr2 = vtov_structure-->VTOVS_RIGHT_INDEX_PROP;
+	if (sym && (obj2 > obj1)) { sym = obj1; obj1 = obj2; obj2 = sym; }
+	if (pr) {
+		! if ((obj1 ofclass Object) && (obj1 provides pr)) i1 = obj1.pr;
+		! else { RunTimeProblem(RTP_IMPREL, obj1, relation); rfalse; }
+		i1 = obj1.pr;
+	} else i1 = obj1-1;
+	if (pr2) {
+		! if ((obj2 ofclass Object) && (obj2 provides pr2)) i2 = obj2.pr2;
+		! else { RunTimeProblem(RTP_IMPREL, obj2, relation); rfalse; }
+		i2 = obj2.pr2;
+	} else i2 = obj2-1;
+	pr = i1*(vtov_structure-->VTOVS_RIGHT_DOMAIN_SIZE) + i2;
+	i1 = IncreasingPowersOfTwo_TB-->(pr%16);
+	pr = pr/16 + 8;
+	if ((vtov_structure-->pr) & i1) rtrue; rfalse;
+];
+-).
+
+[Previous versions of this extension had to patch the template routines that handle various-to-various relations, since I7's generated code called them with hardcoded addresses of the relation storage structures. As of 6E59, however, we can simply change the value in relation-->RR_STORAGE.]
+
+Section 5 - A hack to make block-valued properties work in cloned objects
+
+[ FIXME: The 'pointer valued' property seems to be inaccessible to Inform v10.
+
+This seems to be intentional, see inform7/Internal/Inter/BasicInformKit/kinds/Protocols.neptune:
+
+> builtin protocol POINTER_VALUE_TY {
+> 	conforms-to: SAYABLE_VALUE_TY
+> 	! for internal use only: cannot be named in source text
+> }
+
+Just... try not to use this on value typed properties, please? ]
+
+[ To fix the/-- cloned (P - property) property/--: (- DO_UnlinkProp({P}, (+ new object +)); -). ]
+To fix the/-- cloned (P - property) property/--: (- DO_UnlinkProp({P}, (+ new object +)); -).
+
+Include (-
+[ DO_UnlinkProp prop obj  v;
+	v = obj.prop;
+	obj.prop = BlkValueCreate(BlkValueWeakKind(v));
+	BlkValueCopy(obj.prop, v);
+];
+-).
+
+Dynamic Objects ends here.

--- a/Tara McGrew/Dynamic Objects-v10_0_0.i7xd/extension_metadata.json
+++ b/Tara McGrew/Dynamic Objects-v10_0_0.i7xd/extension_metadata.json
@@ -1,0 +1,8 @@
+{
+    "is": {
+        "type": "extension",
+        "title": "Dynamic Objects",
+        "author": "Tara McGrew",
+        "version": "10.0.0"
+    }
+}

--- a/Tara McGrew/Dynamic Tables-v6_0_0.i7xd/Documentation/Documentation.md
+++ b/Tara McGrew/Dynamic Tables-v6_0_0.i7xd/Documentation/Documentation.md
@@ -1,0 +1,54 @@
+This extension allows the number of rows in a table to be changed at runtime. For example:
+
+	change the Table of Ice Cream Flavors to have 31 rows;
+
+Using that phrase, we may change the size of any table to any non-negative number of rows at any time. After resizing the table, the data that was stored in the table will still be there, the usual table phrases like "the number of rows in Table of Ice Cream Flavors" will reflect the new size, and in general the table will behave exactly as if we had defined it with 31 rows in the source code.
+
+The only way to tell that the table has been resized at all is to use the new phrase "the original number of rows in Table of Ice Cream Flavors", which will return the number of rows that were defined in the source code. If the table hasn't been resized, the original number of rows will be the same as the number of rows.
+
+When we make a table larger, new blank rows are added at the end of the table.
+
+When we make a table smaller, rows are deleted from the end of the table. If the deleted rows aren't blank, the data stored there will be lost. To avoid losing data unnecessarily, we might want to sort the table before making it smaller, since sorting will push all the blank rows to the end.
+
+We can even change a table to have fewer rows than it was defined with. This probably isn't useful, though, since it will use more memory than if we had left the table at its original size.
+
+Changing the size of a table will allocate memory from Inform's heap, the space that's also used for indexed text, lists, and stored actions. The operation might fail if the heap is too full, leaving the table at its old size; this extension won't print an error message, but we can check the number of rows afterward to be sure it succeeded. If we change a table back to its original size, the memory will be reclaimed and the table will go back into the space it originally occupied.
+
+If the game doesn't use indexed text, lists, or stored actions at all, Inform won't normally create a heap, so this extension forces it to create a small heap in that situation (half the normal minimum size). If that isn't big enough, we should add a stored action variable somewhere to make Inform create the heap itself, and then the usual settings like "Use dynamic memory allocation of at least 16384" will work if we need even more space.
+
+Section: Creating New Tables
+
+This extension also allows us to create new tables at runtime, which can be referred to with table-name variables or properties. For example:
+
+	let T be a new table with columns {speaker, quip} and 10 blank rows;
+
+After that phrase, "T" is now a table-name variable pointing to a new table, containing two columns and ten rows. Despite the variable's type being called "table-name", the new table has no actual name, and "say T" will show "** Dynamically created table **" instead.
+
+Note that we have two obligations if we use this syntax. First, we must define the columns ("speaker" and "quip" in this example) in another table in the source code somewhere, so that Inform knows what kinds of value are supposed to go there. We can reuse columns from another table we're already using, or we can define a new table just for this purpose; once the columns have been defined, we can create as many new tables using them as we need.
+
+Second, we must not lose the value of "T", since it's the only way to refer to the new table. If the table is going to stay in use until the end of the game, we should store it in a global variable or a property. If we only need the table temporarily, we should return its memory when we're done with it by writing:
+
+	deallocate T;
+
+(Note that "T" will no longer be a valid table-name once it's been deallocated, so it must not be used afterward.)
+
+To see whether a particular table-name value points to a table that was created this way, we can write:
+
+	if T was dynamically created, [...]
+
+This syntax is useful when we have a table-name variable that might point to a table defined in the source, or maybe a new table, and so we aren't sure whether it needs to be deallocated when we're done with it. It can also be used to check whether the table was created successfully -- if there wasn't enough memory to create the new table, the phrase will return false.
+
+Section: Change Log
+
+Version 2 adds the "new table" and "deallocate table" features.
+
+Version 3 works with Inform 7 version 6E59.
+
+Version 4 fixes a bug where dynamically created tables couldn't be resized.
+
+Version 5 works with (and requires) version 6L38.
+
+Version 5.1 works with (and requires) version 10.1.2.
+
+Version 6 currently works with (and requires) version 10.2. Be aware that 10.2 is in active development, so there is always a chance something may break down the line. The extension was successfully tested with a build of the current Inform master branch from March 24, 2026 at 22:24 GMT.
+

--- a/Tara McGrew/Dynamic Tables-v6_0_0.i7xd/Documentation/Examples/Multiplication.txt
+++ b/Tara McGrew/Dynamic Tables-v6_0_0.i7xd/Documentation/Examples/Multiplication.txt
@@ -1,0 +1,69 @@
+Example: ** Multiplication
+Description: Using the "new table" feature to create a 2D multiplication table using cross references.
+
+A table is a two-dimensional structure already, but you can only access columns by name, not by number. This example shows how to create a table that contains references to other tables, so that we can multiply two numbers by looking up the first one in the master table, cross referencing to another table, and looking up the second number in that other table.
+
+	{*}"Multiplication"
+	
+	Include Dynamic Tables by Tara McGrew.
+	
+	[This is the table we'll fill in with references to the other tables.]
+	
+	Table of Multiplication
+	factor		cross reference
+	a number	a table-name
+	with 19 blank rows.
+	
+	[This table only serves to define the "product" column.]
+	
+	Table of Dummy Columns
+	product
+	a number
+	
+	[Here we fill in the multiplication table, creating a cross reference subtable for each row.]
+	
+	When play begins:
+		repeat with R running from 1 to 20:
+			let the subtable be a new table with columns {factor, product} and 20 blank rows;
+			choose row R in the Table of Multiplication;
+			now the factor entry is R;
+			now the cross reference entry is the subtable;
+			repeat with C running from 1 to 20:
+				choose row C in the subtable;
+				now the factor entry is C;
+				now the product entry is R * C.
+	
+	To look up (X - number) times (Y - number) in the multiplication table:
+		if X is a factor listed in the Table of Multiplication:
+			let the subtable be the cross reference entry;
+			if Y is a factor listed in the subtable:
+				say "[X in capitalized words] times [Y in words] is [product entry in words].";
+				stop;
+		[if we get here, either X or Y are unlisted]
+		say "That isn't in the multiplication table."
+	
+	To say (N - number) in capitalized words:
+		let temp be indexed text;
+		let temp be "[N in words]";
+		say temp in sentence case.
+	
+	[Here we need to do some trickery to get around a parser limitation, because Inform normally can't handle two numbers in the same command.]
+	
+	The other factor is a number that varies.
+	
+	After reading a command:
+		if the player's command includes "by/times [number]":
+			now the other factor is the number understood;
+			replace the matched text with "by __num__".
+	
+	Multiplying is an action applying to one number. Understand "multiply [number] by/times __num__" as multiplying.
+	
+	Carry out multiplying:
+		look up the number understood times the other factor in the multiplication table.
+	
+	Classroom is a room. "This is a peaceful place in which to multiply numbers by other numbers."
+	
+	Test me with "multiply 5 times 6 / multiply 12 by 8 / multiply 67 by 91".
+
+(We could do this without the extension by defining all twenty-one tables in the source text, but that's a lot of typing.)
+

--- a/Tara McGrew/Dynamic Tables-v6_0_0.i7xd/Documentation/Examples/Notlob.txt
+++ b/Tara McGrew/Dynamic Tables-v6_0_0.i7xd/Documentation/Examples/Notlob.txt
@@ -1,0 +1,58 @@
+Example: * Notlob
+Description: A parrot that assigns a value to everything he hears, and repeats the lines back in his preferred order.
+
+The Table of Parrot Quips holds the lines that the parrot has heard, along with a score indicating how much the parrot likes each one, and a usage count to limit the number of times he repeats each one. We use a dynamic table, rather than three lists, because we need to keep the score and usage count associated with the correct text: table sorting keeps rows together, but lists can only be sorted independently of each other.
+
+	{*}"Notlob"
+	
+	Include Dynamic Tables by Tara McGrew.
+	
+	Pet Shoppe is a room. "A sign reads: 'If you're looking for pets, look no further! Pets are something we sell and you can buy them from us.'"
+	
+	The parrot is an animal in the Pet Shoppe. "A parrot is perched here." Instead of buying the parrot, say "Except that one."
+	
+	Table of Parrot Quips
+	quip text	quip score	usage count
+	indexed text	a number	a number
+	
+	The highest quip score is a number that varies. The highest quip score is 0.
+	
+	After answering the parrot that:
+		let the textual quip be indexed text;
+		let the textual quip be the topic understood;
+		let the current quip score be the calculated quip score of the textual quip;
+		if the number of blank rows in the Table of Parrot Quips is 0, change the Table of Parrot Quips to have (2 * the number of rows in the Table of Parrot Quips) rows;
+		choose a blank row in the Table of Parrot Quips;
+		now the quip text entry is the textual quip;
+		now the quip score entry is the current quip score;
+		now the usage count entry is 0;
+		sort the Table of Parrot Quips in reverse quip score order;
+		if the current quip score is greater than the highest quip score:
+			say "The parrot listens intently, whistling with excitement.";
+			now the highest quip score is the current quip score;
+		otherwise:
+			say "The parrot listens."
+	
+	To decide which number is the calculated quip score of (msg - indexed text):
+		let msg be msg in lower case;
+		let the result be 0;
+		repeat with N running from 1 to the number of characters in msg:
+			let C be character number N in msg;
+			if C is "p" or C is "a" or C is "r" or C is "o" or C is "t", increase the result by 1;
+		decide on the result.
+	
+	Every turn when the highest quip score is greater than 0:
+		choose row 1 in the Table of Parrot Quips;
+		say "The parrot squawks, '[quip text entry]'";
+		increase the usage count entry by 1;
+		if the usage count entry is 3:
+			blank out the whole row;
+			if the number of filled rows in the Table of Parrot Quips is 0:
+				now the highest quip score is 0;
+			otherwise:
+				sort the Table of Parrot Quips in reverse quip score order;
+				choose row 1 in the Table of Parrot Quips;
+				now the highest quip score is the quip score entry.
+	
+	Test me with "say hello polly / say hello polly parrot / say i've got a lovely fresh cuttlefish for you / say pining for the fjords / z / z / z / z".
+

--- a/Tara McGrew/Dynamic Tables-v6_0_0.i7xd/Source/Dynamic Tables.i7x
+++ b/Tara McGrew/Dynamic Tables-v6_0_0.i7xd/Source/Dynamic Tables.i7x
@@ -1,0 +1,627 @@
+Version 6.0.0 of Dynamic Tables by Tara McGrew begins here.
+
+"Provides a way to change the capacity of a table during the game."
+
+"ported to Inform v10.1.2 by Alwinfy / further ported to Inform v10.2 (in development) by Taryn Michelle"
+
+Chapter 1 - New stuff
+
+To change (T - table name) to have (N - number) row/rows: (- DT_ResizeTable({T}, {N}); -).
+
+To decide which number is the original number of rows in (T - table name): (- DT_OrigSize({T}) -).
+
+To decide which table name is a new table with columns (CS - list of table columns) and (N - number) blank row/rows: (- DT_NewTable({N}, {-by-reference:CS}); -).
+
+To deallocate (T - table name): (- DT_FreeTable({T}); -).
+
+To decide whether (T - table name) was dynamically created: (- (DT_IsFullyDynamic({T})) -).
+
+[ FIXME: Stubbed as it's hard-coded for Inform v10.
+Include (-
+! Force the heap to be enabled for Dynamic Tables.
+#ifndef MEMORY_HEAP_SIZE;
+Constant MEMORY_HEAP_SIZE = 4096;
+#endif;
+-).
+]
+
+Include (-
+! A column flag to indicate that the table has been resized.
+
+Constant TB_COLUMN_RESIZED $8000;
+
+! Normally, word -->2 of a column contains the index into TB_Blanks where the column's
+! blank bits are stored (unless the TB_COLUMN_NOBLANKBITS flag is set). But since we can't
+! resize TB_Blanks when adding rows to the table, we need a different scheme.
+
+! For resized columns, word -->2 points instead to the table's information block -- the same
+! block for every column -- which contains fields with the offsets listed below.
+! It includes some values from the original (statically allocated) table, which are used to
+! return the table to its statically allocated state if it's ever changed back to the original size.
+
+Constant DT_TIB_ORIGSIZE 0;	! the number of rows originally in the table, or 0 for a fully dynamic table
+Constant DT_TIB_CIBSTART 1;	! the column info blocks start here
+
+! The column information blocks are part of the table information block. Each column's block
+! has a set number of words (DT_CIBSIZE), so the block for column N starts at offset
+! DT_TIB_CIBSTART+((N-1)*DT_CIBSIZE) -- recall that column numbers start at 1.
+
+Constant DT_CIBSIZE 2;
+
+Constant DT_CIB_NEWBLANKS 0;	! address of the dynamically allocated blank bits (if applicable)
+Constant DT_CIB_ORIGDATA 1;	! address of the original (static) column data, or 0 for a fully dynamic table
+
+[ DT_Alloc s  rv;
+	! Pretend we're allocating text, since FlexAllocate demands a valid KOV.
+	rv = FlexAllocate(s, TEXT_TY, 0);
+	if (rv) return rv + BLK_DATA_OFFSET;
+	print "*** Failed to allocate ", s, " bytes ***^";
+	rfalse;
+];
+
+[ DT_Free b; if (b) FlexFree(b - BLK_DATA_OFFSET); ];
+
+[ DT_CopyBytes num src dest  i;
+	#ifdef TARGET_GLULX;
+	@gestalt 6 0 i;
+	if (i) @mcopy num src dest;
+	else for ( i=0: i<num: i++ ) src->i = dest->i;
+	#ifnot;
+	@copy_table src dest num;
+	#endif;
+];
+
+[ DT_ZeroBytes num loc  i;
+	#ifdef TARGET_GLULX;
+	@gestalt 6 0 i;
+	if (i) @mzero num loc;
+	else for ( i=0: i<num: i++ ) loc->i = 0;
+	#ifnot;
+	@copy_table loc 0 num;
+	#endif;
+];
+
+! implements the phrase "change T to have N rows"
+[ DT_ResizeTable tab newsize  cursize i;
+	! don't bother if the new size is no different, or if it's unreasonable
+	cursize = TableRows(tab);
+	if (newsize == cursize || newsize < 0) return;
+	
+	! delegate to a more specific routine
+	if (((tab-->1)-->1) & TB_COLUMN_RESIZED) {
+		if (newsize == ((tab-->1)-->2)-->DT_TIB_ORIGSIZE)
+			DT_DynamicToStatic(tab);
+		else
+			DT_ResizeDynamic(tab, newsize);
+	} else {
+		DT_StaticToDynamic(tab, newsize);
+	}
+
+	newsize = TableRows(tab);
+	for ( i=cursize+1: i<=newsize: i++ ) TableBlankOutRow(tab, i);
+];
+
+! implements the phrase "original number of rows in T"
+[ DT_OrigSize tab;
+	if (((tab-->1)-->1) & TB_COLUMN_RESIZED)
+		return ((tab-->1)-->2)-->DT_TIB_ORIGSIZE;
+	else
+		return TableRows(tab);
+];
+
+! finds the address of the blank bits for a particular table and column, whether or not it's been resized
+[ DT_FindBlankBits tab col  tib cib;
+	if (((tab-->col)-->1) & TB_COLUMN_RESIZED) {
+		tib = (tab-->col)-->2;
+		cib = tib + (DT_TIB_CIBSTART * WORDSIZE);
+		cib = cib + ((DT_CIBSIZE * (col - 1)) * WORDSIZE);
+		return cib-->DT_CIB_NEWBLANKS;
+	} else
+		return TB_Blanks + ((tab-->col)-->2);
+];
+
+! converts a static table to a dynamic one
+[ DT_StaticToDynamic tab newsize  rv nc s tib cib i bbs bba obbs;
+	! allocate TIB
+	nc = tab-->0;
+	s = DT_TIB_CIBSTART;		! # TIB header words
+	s = s + (nc * DT_CIBSIZE);	! # CIB words
+	s = s * WORDSIZE;		! convert words to bytes
+	bbs = (newsize + 7) / 8;		! # blank bytes for each blankable column
+	for ( i=1: i<=nc: i++ ) {
+		if (~~(((tab-->i)-->1) & TB_COLUMN_NOBLANKBITS))
+			s = s + bbs;
+	}
+	tib = DT_Alloc(s); if (~~tib) rfalse;
+
+	! fill it in
+	tib-->DT_TIB_ORIGSIZE = TableRows(tab);
+	cib = tib + (DT_TIB_CIBSTART * WORDSIZE);
+	bba = cib + (nc * DT_CIBSIZE * WORDSIZE);
+	obbs = (((tab-->1)-->0) + 7) / 8;	! # blank bytes in old table
+	for ( i=1: i<=nc: i++ ) {
+		! fill in CIB
+		if (~~(((tab-->i)-->1) & TB_COLUMN_NOBLANKBITS)) {
+			cib-->DT_CIB_NEWBLANKS = bba;
+			DT_CopyBlanks(TB_Blanks + ((tab-->i)-->2), obbs, bba, bbs);
+			bba = bba + bbs;
+		} else
+			cib-->DT_CIB_NEWBLANKS = 0;
+		cib-->DT_CIB_ORIGDATA = tab-->i;
+
+		! allocate new column
+		rv = DT_CopyColumn(tab-->i, newsize, 0, tib);
+		if (~~rv) { DT_BackOutDyn(tab, tib, i - 1); rfalse; }
+		tab-->i = rv;
+
+		! advance to next CIB
+		cib = cib + (DT_CIBSIZE * WORDSIZE);
+	}
+
+	! success
+	rtrue;
+];
+
+! clean up after DT_StaticToDynamic and DT_ResizeDynamic when memory has run out
+[ DT_BackOutDyn tab tib copiedcols  i j col ocol;
+	for ( i=1: i<=copiedcols: i++ ) {
+		! move block references back from the copied column before freeing values
+		ocol = tib-->(DT_TIB_CIBSTART + (DT_CIBSIZE * (i - 1)) + DT_CIB_ORIGDATA);
+		col = tab-->i;
+		if ((col-->1) & TB_COLUMN_ALLOCATED) {
+			for ( j=3: j<=col-->0: j++ ) {
+				ocol-->j = col-->j;
+				col-->j = 0;
+			}
+		}
+		DT_FreeColumnValues(tab, col); DT_Free(col);
+		tab-->i = ocol;
+	}
+	DT_Free(tib);
+];
+
+! converts a dynamic table to a static one
+[ DT_DynamicToStatic tab  tib cib cursize newsize nc i bbs obbs dcol scol;
+	cursize = (tab-->1)-->0;
+	tib = (tab-->1)-->2;
+	newsize = tib-->DT_TIB_ORIGSIZE;
+
+	! copy data into static table
+	nc = tab-->0;
+	cib = tib + (DT_TIB_CIBSTART * WORDSIZE);
+	bbs = (newsize + 7) / 8;
+	obbs = (cursize + 7) / 8;
+	for ( i=1: i<=nc: i++ ) {
+		dcol = tab-->i;
+		scol = cib-->DT_CIB_ORIGDATA;
+
+		! copy blanks
+		if (~~(((dcol)-->1) & TB_COLUMN_NOBLANKBITS))
+			DT_CopyBlanks(cib-->DT_CIB_NEWBLANKS, obbs, TB_Blanks + (scol-->2), bbs);
+
+		! copy values
+		DT_CopyColumn(dcol, newsize, scol);
+		DT_FreeColumnValues(tab, dcol);
+		DT_Free(dcol);
+		tab-->i = scol;
+
+		! advance to next CIB
+		cib = cib + (DT_CIBSIZE * WORDSIZE);
+	}
+
+	! success
+	DT_Free(tib);
+	rtrue;
+];
+
+! changes the size of a table that's already dynamic
+[ DT_ResizeDynamic tab newsize  nc s bbs bba obbs tib cib otib ocib i rv;
+	! allocate new TIB
+	nc = tab-->0;
+	s = DT_TIB_CIBSTART;		! # TIB header words
+	s = s + (nc * DT_CIBSIZE);	! # CIB words
+	s = s * WORDSIZE;		! convert words to bytes
+	bbs = (newsize + 7) / 8;		! # blank bytes for each blankable column
+	for ( i=1: i<=nc: i++ ) {
+		if (~~(((tab-->i)-->1) & TB_COLUMN_NOBLANKBITS))
+			s = s + bbs;
+	}
+	tib = DT_Alloc(s); if (~~tib) rfalse;
+
+	! fill it in
+	otib = (tab-->1)-->2;
+	ocib = otib + (DT_TIB_CIBSTART * WORDSIZE);
+	tib-->DT_TIB_ORIGSIZE = otib-->DT_TIB_ORIGSIZE;
+	cib = tib + (DT_TIB_CIBSTART * WORDSIZE);
+	bba = cib + (nc * DT_CIBSIZE * WORDSIZE);
+	obbs = (((tab-->1)-->0) + 7) / 8;	! # blank bytes in old table
+	for ( i=1: i<=nc: i++ ) {
+		! fill in CIB
+		if (~~(((tab-->i)-->1) & TB_COLUMN_NOBLANKBITS)) {
+			cib-->DT_CIB_NEWBLANKS = bba;
+			DT_CopyBlanks(ocib-->DT_CIB_NEWBLANKS, obbs, bba, bbs);
+			bba = bba + bbs;
+		} else
+			cib-->DT_CIB_NEWBLANKS = 0;
+
+		! save a pointer to the old *dynamic* column in case we need to back out.
+		! it'll be changed to the static column later if we succeed.
+		cib-->DT_CIB_ORIGDATA = tab-->i;
+
+		! allocate new column
+		rv = DT_CopyColumn(tab-->i, newsize, 0, tib);
+		if (~~rv) { DT_BackOutDyn(tab, tib, i - 1); rfalse; }
+		tab-->i = rv;
+
+		! advance to next CIB
+		cib = cib + (DT_CIBSIZE * WORDSIZE);
+		ocib = ocib + (DT_CIBSIZE * WORDSIZE);
+	}
+
+	! success: now we can fix the origdata pointers
+	cib = tib + (DT_TIB_CIBSTART * WORDSIZE);
+	ocib = otib + (DT_TIB_CIBSTART * WORDSIZE);
+	for ( i=1: i<=nc: i++ ) {
+		! free the old dynamic column
+		rv = cib-->DT_CIB_ORIGDATA;
+		DT_FreeColumnValues(tab, rv);
+		DT_Free(rv);
+
+		! fix the pointer
+		cib-->DT_CIB_ORIGDATA = ocib-->DT_CIB_ORIGDATA;
+
+		! advance to next CIB
+		cib = cib + (DT_CIBSIZE * WORDSIZE);
+		ocib = ocib + (DT_CIBSIZE * WORDSIZE);
+	}
+	DT_Free(otib);
+	rtrue;
+];
+
+[ DT_CopyBlanks src sbytes dest dbytes  size;
+	if (dbytes > sbytes) {
+		DT_CopyBytes(sbytes, src, dest);
+		dest = dest + sbytes;
+		dbytes = dbytes - sbytes;
+		DT_ZeroBytes(dbytes, dest);		
+	} else
+		DT_CopyBytes(dbytes, src, dest);
+];
+
+[ DT_CopyColumn col newsize rv bbptr  i kov tc dest oldsize;
+	if (rv == 0) {
+		! allocate new column
+		i = (newsize + COL_HSIZE + 1) * WORDSIZE;
+		rv = DT_Alloc(i); if (~~rv) rfalse;
+		rv-->0 = newsize + COL_HSIZE;
+		rv-->1 = (col-->1) | TB_COLUMN_RESIZED;
+		rv-->2 = bbptr;
+	}
+
+	kov = UNKNOWN_TY;
+	if ((col-->1) & TB_COLUMN_ALLOCATED) {
+		tc = (col-->1) & TB_COLUMN_NUMBER;
+		kov = TC_KOV(tc);
+	}
+
+	oldsize = (col-->0) - COL_HSIZE;
+
+	if (kov == UNKNOWN_TY) {
+		if (oldsize < newsize) i = oldsize * WORDSIZE; else i = newsize * WORDSIZE;
+		dest = rv + ((COL_HSIZE + 1) * WORDSIZE);
+		col = col + ((COL_HSIZE + 1) * WORDSIZE);
+		DT_CopyBytes(i, col, dest);
+		if (newsize > oldsize) {
+			i = (newsize - oldsize) * WORDSIZE;
+			dest = dest + (oldsize * WORDSIZE);
+			DT_ZeroBytes(i, dest);
+		}
+	} else {
+		for ( i=1: i<=newsize: i++ ) {
+			if (i <= oldsize) {
+				! new column takes ownership of the pointer
+				tc = col-->(COL_HSIZE + i);
+				col-->(COL_HSIZE + i) = 0;
+			} else
+				tc = BlkValueCreate(kov);
+			rv-->(COL_HSIZE + i) = tc;
+		}
+	}
+
+	return rv;
+];
+
+[ DT_FreeColumnValues tab col  kov tc i v;
+	kov = UNKNOWN_TY;
+	if ((col-->1) & TB_COLUMN_ALLOCATED) {
+		tc = (col-->1) & TB_COLUMN_NUMBER;
+		kov = TC_KOV(tc);
+	}
+
+	if (kov ~= UNKNOWN_TY) {
+		tc = col-->0;
+		for ( i=3: i<=tc: i++ ) {
+			v = col-->i;
+			if (v==0) continue;
+			if (v==TABLE_NOVALUE && CheckTableEntryIsBlank(tab, col, i - 2)) continue;
+			FlexFree(v);
+			col-->i = 0;
+		}
+	}
+];
+
+! implements the phrase "a new table with columns {C} and N blank rows"
+[ DT_NewTable nrows collist  nc i rv tib cib s bbs bba tc kov fl;
+	nc = LIST_OF_TY_GetLength(collist);
+
+	! allocate space for table header
+	s = 1 + nc;			! table header (size word + column pointers)
+	
+	rv = DT_Alloc(s); if (~~rv) rfalse;
+	rv-->0 = nc;
+	
+	! allocate space for TIB
+	s = DT_TIB_CIBSTART;		! # TIB header words
+	s = s + (nc * DT_CIBSIZE);	! # CIB words
+	s = s * WORDSIZE;		! convert words to bytes
+	bbs = (nrows + 7) / 8;		! # blank bytes for each blankable column
+	s = s + (bbs * nc);			! (we make every column blankable here)
+	
+	tib = DT_Alloc(s); if (~~tib) { DT_Free(rv); rfalse; }
+
+	! fill in TIB
+	tib-->DT_TIB_ORIGSIZE = 0;
+	cib = tib + (DT_TIB_CIBSTART * WORDSIZE);
+	bba = cib + (nc * DT_CIBSIZE * WORDSIZE);
+	for ( i=1: i<=nc: i++ ) {
+		! look up the column's KOV
+		tc = LIST_OF_TY_GetItem(collist, i);
+		kov = TC_KOV(tc);
+
+		! fill in CIB
+		cib-->DT_CIB_NEWBLANKS = bba;
+		DT_ZeroBytes(bbs, bba);
+		bba = bba + bbs;
+		cib-->DT_CIB_ORIGDATA = 0;
+
+		! allocate new column
+		s = DT_Alloc((3 + nrows) * WORDSIZE);
+		if (~~s) { DT_BackOutNew(rv, i - 1); rfalse; }
+		rv-->i = s;
+
+		! figure out column flags and fill in column header
+		tc = tc | TB_COLUMN_RESIZED;
+		if (kov == NUMBER_TY or TIME_TY || kov >= 100)
+			tc = tc | TB_COLUMN_SIGNED;
+		if (kov == UNDERSTANDING_TY)
+			tc = tc | TB_COLUMN_TOPIC;
+		if (kov == NUMBER_TY or TIME_TY or LIST_OF_TY or TEXT_TY || kov >= 100)
+			tc = tc | TB_COLUMN_CANEXCHANGE;
+		if (KOVIsBlockValue(kov))
+			tc = tc | TB_COLUMN_ALLOCATED;
+		s-->0 = 2 + nrows;
+		s-->1 = tc;
+		s-->2 = tib;
+
+		! advance to next CIB
+		cib = cib + (DT_CIBSIZE * WORDSIZE);
+	}
+
+	! leave the table blank
+	for (i=1: i<=nrows: i++) TableBlankOutRow(rv, i);
+
+	return rv;
+];
+
+! clean up after DT_NewTable when memory has run out
+[ DT_BackOutNew tab donecols  i;
+	for ( i=1: i<=donecols: i++ )
+		DT_Free(tab-->i);
+	DT_Free(tab);
+];
+
+[ DT_IsFullyDynamic tab;
+	if (tab == 0) rfalse;
+	if (((tab-->1)-->1 & TB_COLUMN_RESIZED) == 0) rfalse;
+	if (((tab-->1)-->2)-->DT_TIB_ORIGSIZE ~= 0) rfalse;
+	rtrue;
+];
+
+! implements the phrase "deallocate T"
+[ DT_FreeTable tab  i nc tib;
+	if (DT_IsFullyDynamic(tab)) {
+		nc = tab-->0;
+		tib = (tab-->1)-->2;
+		for (i=1: i<=nc: i++) {
+			DT_FreeColumnValues(tab, tab-->i);
+			DT_Free(tab-->i);
+		}
+		DT_Free(tib);
+		DT_Free(tab);
+		rtrue;
+	}
+	print "*** Tried to deallocate a table that wasn't dynamically created ***^";
+	rfalse;
+];
+-) after "Flex.i6t".
+
+Chapter 2 - Library replacements
+
+Section 1 - Using the dynamic blank bits
+
+[We need to change the parts of Tables.i6t that directly use TB_Blanks to call DT_FindBlankBits instead.]
+
+Include (-
+[ CheckTableEntryIsBlank tab col row i at oldv flags;
+	if (col >= 100) col = TableFindCol(tab, col);
+	if (col == 0) rtrue;
+	if ((tab-->col)-->(row+COL_HSIZE) ~= TABLE_NOVALUE) {
+		print "*** CTEIB on nonblank value ", tab, " ", col, " ", row, " ***^";
+	}
+	if (((tab-->col)-->1) & TB_COLUMN_NOBLANKBITS) rtrue;
+	row--;
+	at = DT_FindBlankBits(tab, col) + (row/8);
+	if ((at->0) & (CheckTableEntryIsBlank_LU->(row%8))) rtrue;
+	rfalse;
+];
+-) replacing "CheckTableEntryIsBlank".
+
+Include (-
+[ ForceTableEntryBlank tab col row i at oldv flags;
+	if (col >= 100) col = TableFindCol(tab, col);
+	if (col == 0) rtrue;
+	flags = (tab-->col)-->1;
+	oldv = (tab-->col)-->(row+COL_HSIZE);
+	if ((flags & TB_COLUMN_ALLOCATED) && (oldv ~= 0 or TABLE_NOVALUE))
+		FlexFree(oldv);
+	(tab-->col)-->(row+COL_HSIZE) = TABLE_NOVALUE;
+	if (flags & TB_COLUMN_NOBLANKBITS) return;
+	row--;
+	at = DT_FindBlankBits(tab, col) + (row/8);
+	(at->0) = (at->0) | (CheckTableEntryIsBlank_LU->(row%8));
+];
+-) replacing "ForceTableEntryBlank".
+
+Include (-
+[ ForceTableEntryNonBlank tab col row i at oldv flags tc kov j;
+	if (col >= 100) col=TableFindCol(tab, col);
+	if (col == 0) rtrue;
+	if (((tab-->col)-->1) & TB_COLUMN_NOBLANKBITS) return;
+	flags = (tab-->col)-->1;
+	oldv = (tab-->col)-->(row+COL_HSIZE);
+	if ((flags & TB_COLUMN_ALLOCATED) &&
+		(oldv == 0 or TABLE_NOVALUE)) {
+		kov = UNKNOWN_TY;
+		tc = ((tab-->col)-->1) & TB_COLUMN_NUMBER;
+		kov = TC_KOV(tc);
+		if (kov ~= UNKNOWN_TY) {
+			if (KindBaseArity(kov) > 0) i = KindAtomic(kov); else i = 0;
+			(tab-->col)-->(row+COL_HSIZE) = BlkValueCreate(kov, 0, i);
+		}
+	}
+	row--;
+	at = DT_FindBlankBits(tab, col) + (row/8);
+	(at->0) = (at->0) & (CheckTableEntryIsNonBlank_LU->(row%8));
+];
+-) replacing "ForceTableEntryNonBlank".
+
+Include (-
+[ TableSwapBlankBits tab row1 row2 col at1 at2 bit1 bit2;
+	if (col >= 100) col=TableFindCol(tab, col);
+	if (col == 0) rtrue;
+	if (((tab-->col)-->1) & TB_COLUMN_NOBLANKBITS) return;
+	row1--;
+	at1 = DT_FindBlankBits(tab, col) + (row1/8);
+	row2--;
+	at2 = DT_FindBlankBits(tab, col) + (row2/8);
+	bit1 = ((at1->0) & (CheckTableEntryIsBlank_LU->(row1%8)));
+	bit2 = ((at2->0) & (CheckTableEntryIsBlank_LU->(row2%8)));
+	if (bit1) bit1 = true; 
+	if (bit2) bit2 = true;
+	if (bit1 == bit2) return;
+	if (bit1) {
+		(at1->0)
+			= (at1->0) & (CheckTableEntryIsNonBlank_LU->(row1%8));
+		(at2->0)
+			= (at2->0) | (CheckTableEntryIsBlank_LU->(row2%8));
+	} else {
+		(at1->0)
+			= (at1->0) | (CheckTableEntryIsBlank_LU->(row1%8));
+		(at2->0)
+			= (at2->0) & (CheckTableEntryIsNonBlank_LU->(row2%8));
+	}
+];
+-) replacing "TableSwapBlankBits".
+
+Include (-
+[ TableMoveBlankBitsDown tab row1 row2 col at atp1 bit rx bba;
+	if (col >= 100) col=TableFindCol(tab, col);
+	if (col == 0) rtrue;
+	if (((tab-->col)-->1) & TB_COLUMN_NOBLANKBITS) return;
+	row1--; row2--;
+	! Read blank bit for row1:
+	bba = DT_FindBlankBits(tab, col);
+	at = bba + (row1/8);
+	bit = ((at->0) & (CheckTableEntryIsBlank_LU->(row1%8)));
+	if (bit) bit = true;
+	! Loop through, setting each blank bit to the next:
+	for (rx=row1:rx<row2:rx++) {
+		atp1 = bba + ((rx+1)/8);
+		at = bba + (rx/8);
+		if ((atp1->0) & (CheckTableEntryIsBlank_LU->((rx+1)%8))) {
+			(at->0)
+				= (at->0) | (CheckTableEntryIsBlank_LU->(rx%8));
+		} else {
+			(at->0)
+				= (at->0) & (CheckTableEntryIsNonBlank_LU->(rx%8));
+		}
+	}
+	! Write bit to blank bit for row2:
+	at = bba + (row2/8);
+	if (bit) {
+		(at->0)
+			= (at->0) | (CheckTableEntryIsBlank_LU->(row2%8));
+	} else {
+		(at->0)
+			= (at->0) & (CheckTableEntryIsNonBlank_LU->(row2%8));
+	}
+];
+-) replacing "TableMoveBlankBitsDown".
+
+[And here we replace PrintTableName to show something sensible for fully dynamic tables.]
+
+[ TODO stubbed
+Include (-
+[ PrintTableName T;
+	switch(T) {
+{-call:Tables::Support::compile_print_table_names}
+		default:
+			if (DT_IsFullyDynamic(T))
+				print "** Dynamically created table **";
+			else
+				print "** No such table **";
+	}
+];
+-) replacing "Print Table Name".
+]
+
+Section 2 - Missing from Inform 10.2 BasicInformKit 
+
+[ // TM 2026-03-28 - The following Inform6 functions have been copied from the version 10.1 Basic Inform template. 
+The fact that they no longer appear in the 10.2 Basic Inform "kit" suggests an intentional move away from these methods. 
+If I understand the direction correctly, going forward, Inform means to allow more flexibility with respect to the addition of new "kinds", so while restoring the below four functions "works" 
+at this point with the current build of 10.2, it may not suffice to handle the changes that are coming. At the least, keep this in mind when making use of any new "kind" creation features of the language, 
+and be sure to test thoroughly before relying on this extension.  ]
+
+Include (-
+[ KOVIsBlockValue 
+	k ! Implied call parameter
+	;
+	k = KindAtomic(k);
+	if (k == 14 or 30 or 34 or 38 or 40) rtrue;
+	rfalse;
+];
+-).
+
+Include (-
+[ KindAtomic kind;
+	if ((kind >= 0) && (kind < BASE_KIND_HWM)) return kind;
+	return kind-->0;
+];
+-).
+
+Include(-
+[ KindBaseArity kind;
+	if ((kind >= 0) && (kind < BASE_KIND_HWM)) return 0;
+	return kind-->1;
+];
+-).
+
+Include(- 
+[ KindBaseTerm kind n;
+	if ((kind >= 0) && (kind < BASE_KIND_HWM)) return UNKNOWN_TY;
+	return kind-->(2+n);
+];
+-).
+
+Dynamic Tables ends here.

--- a/Tara McGrew/Dynamic Tables-v6_0_0.i7xd/extension_metadata.json
+++ b/Tara McGrew/Dynamic Tables-v6_0_0.i7xd/extension_metadata.json
@@ -1,0 +1,8 @@
+{
+    "is": {
+        "type": "extension",
+        "title": "Dynamic Tables",
+        "author": "Tara McGrew",
+        "version": "6.0.0"
+    }
+}

--- a/Zed Lopez/Unit Tests-v7_0_2.i7xd/Documentation/Examples/WhoTestsTheTesters.txt
+++ b/Zed Lopez/Unit Tests-v7_0_2.i7xd/Documentation/Examples/WhoTestsTheTesters.txt
@@ -1,4 +1,4 @@
-Example: * Who tests the testers?
+Example: * Who tests the testers
 
 	{*}"Unit Tests"
 	


### PR DESCRIPTION
Adding updated versions of Dynamic Tables and Dynamic Objects extensions (both by Tara McGrew) for compatabiity with 10.2/11.0 Inform development 

I seem to have screwed up the last pull request -- hoping this goes better. 

Besides the two extensions, there are two other minor commits in this pull request. When I set about cloning the repository locally,  the checkout failed, on account of two code samples, each of which had a question mark (?) in their filenames. I'm working in a Windows development environment, so that caused an "invalid filename" error. 

I edited the two filenames  directly in github, stripping off the trailing "?". I could have ignored the issue and worked around it, but it feels cleaner to be working with a properly cloned and checked out working repository, plus if any other Windows users come along and want to clone the 11.0 branch, they won't run into the same problem I did. Hope that's okay.  

<!--

Thank you for adding or updating an extension!

This extension now requires all extensions for Inform 7 release 10.1 and 9.3 (6M62) to be production-ready. Any extensions for older Inform 7 releases or for experiments and works-in-progress, should be committed to the [master branch](https://github.com/i7/extensions/tree/master).

-->
